### PR TITLE
Fix csv value serialization when creating an ERP redeem script

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>co.rsk.bitcoinj</groupId>
-    <version>0.14.4-rsk-11</version>
+    <version>0.14.4-rsk-12</version>
     <artifactId>bitcoinj-thin</artifactId>
 
     <name>bitcoinj-thin</name>

--- a/src/main/java/co/rsk/bitcoinj/core/Utils.java
+++ b/src/main/java/co/rsk/bitcoinj/core/Utils.java
@@ -99,6 +99,20 @@ public class Utils {
         return result;
     }
 
+    public static byte[] unsignedLongToByteArrayLE(long number, int numBytes) {
+        if (number < 0) {
+            throw new VerificationException("Number needs to be positive");
+        }
+        validateNumberFitsInByteArray(number, numBytes);
+
+        byte[] result = new byte[numBytes];
+        for (int i = 0; i < numBytes; i++) {
+            result[i] = (byte)(number & 0xFF);
+            number >>= 8;
+        }
+        return result;
+    }
+
     public static void uint32ToByteArrayBE(long val, byte[] out, int offset) {
         out[offset] = (byte) (0xFF & (val >> 24));
         out[offset + 1] = (byte) (0xFF & (val >> 16));

--- a/src/main/java/co/rsk/bitcoinj/core/Utils.java
+++ b/src/main/java/co/rsk/bitcoinj/core/Utils.java
@@ -85,7 +85,7 @@ public class Utils {
         return bytes;        
     }
 
-    public static byte[] unsignedLongToByteArray(long number, int numBytes) {
+    public static byte[] unsignedLongToByteArrayBE(long number, int numBytes) {
         if (number < 0) {
             throw new VerificationException("Number needs to be positive");
         }
@@ -181,8 +181,9 @@ public class Utils {
         // We could use the XOR trick here but it's easier to understand if we don't. If we find this is really a
         // performance issue the matter can be revisited.
         byte[] buf = new byte[bytes.length];
-        for (int i = 0; i < bytes.length; i++)
+        for (int i = 0; i < bytes.length; i++) {
             buf[i] = bytes[bytes.length - 1 - i];
+        }
         return buf;
     }
     

--- a/src/main/java/co/rsk/bitcoinj/core/Utils.java
+++ b/src/main/java/co/rsk/bitcoinj/core/Utils.java
@@ -113,6 +113,11 @@ public class Utils {
         return result;
     }
 
+    public static byte[] signedLongToByteArrayLE(long number) {
+        byte[] numberBytes = BigInteger.valueOf(number).toByteArray(); // BigInteger serializes with a sign MSB
+        return reverseBytes(numberBytes);
+    }
+
     public static void uint32ToByteArrayBE(long val, byte[] out, int offset) {
         out[offset] = (byte) (0xFF & (val >> 24));
         out[offset + 1] = (byte) (0xFF & (val >> 16));
@@ -164,8 +169,9 @@ public class Utils {
         bytes = reverseBytes(bytes);
         stream.write(bytes);
         if (bytes.length < 8) {
-            for (int i = 0; i < 8 - bytes.length; i++)
+            for (int i = 0; i < 8 - bytes.length; i++) {
                 stream.write(0);
+            }
         }
     }
 

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -48,7 +48,8 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
         return new Script(chunksForRedeem);
     }
 
-    public static Script createErpRedeemScript(
+    @Deprecated
+    public static Script createErpRedeemScriptDeprecated(
         Script defaultFederationRedeemScript,
         Script erpFederationRedeemScript,
         Long csvValue

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser {
     private static final Logger logger = LoggerFactory.getLogger(ErpFederationRedeemScriptParser.class);
+    public static long MIN_CSV_VALUE = 256L; // 65535 is 2 bytes. The max value currently accepted
     public static long MAX_CSV_VALUE = 65_535L; // 65535 is 2 bytes. The max value currently accepted
     public static int CSV_SERIALIZED_LENGTH = 2;
 
@@ -111,7 +112,6 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
             .build();
     }
 
-
     private static void validateErpRedeemScriptValues(
         Script defaultFederationRedeemScript,
         Script erpFederationRedeemScript,
@@ -126,14 +126,14 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
             throw new VerificationException(message);
         }
 
-        if (csvValue > MAX_CSV_VALUE) {
-            String message = "Provided csv Value surpasses the limit of " + MAX_CSV_VALUE;
-            logger.warn("[validateErpRedeemScriptValues] {}", message);
-            throw new VerificationException(message);
-        }
-
-        if (csvValue < 0) {
-            String message = "Provided csv Value is smaller than 0";
+        if (csvValue < MIN_CSV_VALUE || csvValue > MAX_CSV_VALUE) {
+            String message = String.format(
+                "Provided csv value %d must be between %d and %d to ensure the use of %d bytes for serialization",
+                csvValue,
+                MIN_CSV_VALUE,
+                MAX_CSV_VALUE,
+                CSV_SERIALIZED_LENGTH
+            );
             logger.warn("[validateErpRedeemScriptValues] {}", message);
             throw new VerificationException(message);
         }

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser {
     private static final Logger logger = LoggerFactory.getLogger(ErpFederationRedeemScriptParser.class);
 
+    public static long MAX_CSV_VALUE = 105_120L; // 2 years in BTC blocks (considering 1 block every 10 minutes)
+
     public ErpFederationRedeemScriptParser(
         ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks,
@@ -137,8 +139,12 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
             throw new VerificationException(message);
         }
 
-        if (csvValue <= 0) {
-            String message = String.format("Provided csv value %d must be larger than 0", csvValue);
+        if (csvValue <= 0 || csvValue > MAX_CSV_VALUE) {
+            String message = String.format(
+                "Provided csv value %d must be larger than 0 and lower than %d",
+                csvValue,
+                MAX_CSV_VALUE
+            );
             logger.warn("[validateErpRedeemScriptValues] {}", message);
             throw new VerificationException(message);
         }

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -65,6 +65,8 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     }
 
     @Deprecated
+    // This method encodes the CSV value as Big Endian which is not correct. It should be encoded as LE
+    // Keeping this method for backwards compatibility in rskj
     public static Script createErpRedeemScriptDeprecated(
         Script defaultFederationRedeemScript,
         Script erpFederationRedeemScript,

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 
 public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser {
     private static final Logger logger = LoggerFactory.getLogger(ErpFederationRedeemScriptParser.class);
-    public static long MIN_CSV_VALUE = 256L; // 65535 is 2 bytes. The max value currently accepted
-    public static long MAX_CSV_VALUE = 65_535L; // 65535 is 2 bytes. The max value currently accepted
+    public static long MIN_CSV_VALUE = 256L; // 256  is the minimum value that can be represented using 2 bytes without adding extra zeroes
+    public static long MAX_CSV_VALUE = 65_535L; // 65_535 is the maximum value that can be represented using 2 bytes
     public static int CSV_SERIALIZED_LENGTH = 2;
 
     public ErpFederationRedeemScriptParser(

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser {
     private static final Logger logger = LoggerFactory.getLogger(ErpFederationRedeemScriptParser.class);
 
-    public static long MAX_CSV_VALUE = 105_120L; // 2 years in BTC blocks (considering 1 block every 10 minutes)
+    public static long MAX_CSV_VALUE = 65_535L; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value
 
     public ErpFederationRedeemScriptParser(
         ScriptType scriptType,

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -52,8 +52,7 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
         Script erpFederationRedeemScript,
         Long csvValue
     ) {
-        byte[] csvValueBytes = BigInteger.valueOf(csvValue).toByteArray();
-        byte[] serializedCsvValue = Utils.reverseBytes(csvValueBytes); // LE encoding
+        byte[] serializedCsvValue = Utils.signedLongToByteArrayLE(csvValue);
 
         return createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -64,7 +63,8 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     }
 
     @Deprecated
-    // This method encodes the CSV value as Big Endian which is not correct. It should be encoded as LE
+    // This method encodes the CSV value as unsigned Big Endian which is not correct.
+    // It should be encoded as signed LE
     // Keeping this method for backwards compatibility in rskj
     public static Script createErpRedeemScriptDeprecated(
         Script defaultFederationRedeemScript,

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -54,7 +54,7 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
         Script erpFederationRedeemScript,
         Long csvValue
     ) {
-        byte[] parsedCsvValue = Utils.unsignedLongToByteArray(csvValue, CSV_SERIALIZED_LENGTH);
+        byte[] parsedCsvValue = Utils.unsignedLongToByteArrayBE(csvValue, CSV_SERIALIZED_LENGTH);
 
         validateErpRedeemScriptValues(
             defaultFederationRedeemScript,

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -47,29 +47,6 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
             .build();
     }
 
-    public static Script createFastBridgeErpRedeemScript(
-        Script defaultFederationRedeemScript,
-        Script erpFederationRedeemScript,
-        Long csvValue,
-        Sha256Hash derivationArgumentsHash
-    ) {
-        if (!RedeemScriptValidator.hasStandardRedeemScriptStructure(defaultFederationRedeemScript.getChunks()) ||
-            !RedeemScriptValidator.hasStandardRedeemScriptStructure(erpFederationRedeemScript.getChunks())) {
-
-            String message = "Provided redeem scripts have an invalid structure, not standard";
-            logger.debug("[createFastBridgeErpRedeemScript] {}", message);
-            throw new VerificationException(message);
-        }
-
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue
-        );
-
-        return createFastBridgeErpRedeemScript(erpRedeemScript, derivationArgumentsHash);
-    }
-
     public static boolean isFastBridgeErpFed(List<ScriptChunk> chunks) {
         return RedeemScriptValidator.hasFastBridgePrefix(chunks) &&
             RedeemScriptValidator.hasErpRedeemScriptStructure(chunks.subList(2, chunks.size()));

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -1,19 +1,26 @@
 package co.rsk.bitcoinj.script;
 
-import static co.rsk.bitcoinj.script.ScriptOpCodes.OP_CHECKMULTISIG;
-import static co.rsk.bitcoinj.script.ScriptOpCodes.OP_CHECKMULTISIGVERIFY;
-
 import co.rsk.bitcoinj.core.ScriptException;
+import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RedeemScriptParserFactory {
-
+    private static final byte[] ERP_TESTNET_REDEEM_SCRIPT_BYTES = Utils.HEX.decode("6453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f42102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a0921039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb955670300cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368ae");
     private static final Logger logger = LoggerFactory.getLogger(RedeemScriptParserFactory.class);
 
     public static RedeemScriptParser get(List<ScriptChunk> chunks) {
+        // Due to a validation error, during the time this federation existed in testnet
+        // bitcoinj-thin would not detect it correctly as an ERP fed
+        // We need to keep this behaviour for the given redeem script to keep the consensus in testnet
+        ScriptParserResult scriptParserResult = ScriptParser.parseScriptProgram(ERP_TESTNET_REDEEM_SCRIPT_BYTES);
+        if (scriptParserResult.getChunks().equals(chunks)) {
+            logger.debug("[get] Received redeem script matches the testnet federation hardcoded one. Return NoRedeemScriptParser");
+            return new NoRedeemScriptParser();
+        }
+
         if (chunks.size() < 4) {
             // A multisig redeem script must have at least 4 chunks (OP_N [PUB1 ...] OP_N CHECK_MULTISIG)
             logger.debug("[get] Less than 4 chunks, return NoRedeemScriptParser");
@@ -70,7 +77,7 @@ public class RedeemScriptParserFactory {
         }
         if (lastChunk.data != null && lastChunk.data.length > 0) {
             int lastByte = lastChunk.data[lastChunk.data.length - 1] & 0xff;
-            if (lastByte == OP_CHECKMULTISIG || lastByte == OP_CHECKMULTISIGVERIFY) {
+            if (lastByte == ScriptOpCodes.OP_CHECKMULTISIG || lastByte == ScriptOpCodes.OP_CHECKMULTISIGVERIFY) {
                 ScriptParserResult result = ScriptParser.parseScriptProgram(lastChunk.data);
                 if (result.getException().isPresent()) {
                     String message = String.format("Error trying to parse inner script. %s", result.getException().get());

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptValidator.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptValidator.java
@@ -79,7 +79,7 @@ public class RedeemScriptValidator {
                 ScriptChunk csvOpcode = chunks.get(elseOpcodeIndex + 2);
                 ScriptChunk opDrop = chunks.get(elseOpcodeIndex + 3);
 
-                hasErpStructure = pushBytesOpcode.opcode == ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH &&
+                hasErpStructure = pushBytesOpcode.isPushData() &&
                     csvOpcode.equalsOpCode(ScriptOpCodes.OP_CHECKSEQUENCEVERIFY) &&
                     opDrop.equalsOpCode(ScriptOpCodes.OP_DROP);
 

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptValidator.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptValidator.java
@@ -1,10 +1,6 @@
 package co.rsk.bitcoinj.script;
 
-import static co.rsk.bitcoinj.script.ScriptOpCodes.OP_CHECKMULTISIG;
-import static co.rsk.bitcoinj.script.ScriptOpCodes.OP_CHECKMULTISIGVERIFY;
-
 import co.rsk.bitcoinj.core.VerificationException;
-import java.math.BigInteger;
 import java.util.List;
 
 public class RedeemScriptValidator {
@@ -17,7 +13,7 @@ public class RedeemScriptValidator {
         ScriptChunk lastChunk = chunks.get(chunks.size() - 1);
         // Must end in OP_CHECKMULTISIG[VERIFY]
         return lastChunk.isOpCode() &&
-            (lastChunk.equalsOpCode(OP_CHECKMULTISIG) || lastChunk.equalsOpCode(OP_CHECKMULTISIGVERIFY));
+            (lastChunk.equalsOpCode(ScriptOpCodes.OP_CHECKMULTISIG) || lastChunk.equalsOpCode(ScriptOpCodes.OP_CHECKMULTISIGVERIFY));
     }
 
     protected static boolean hasStandardRedeemScriptStructure(List<ScriptChunk> chunks) {

--- a/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
@@ -68,27 +68,35 @@ public class UtilsTest {
         final int numBytes = 2;
 
         long value = 1L;
+        byte[] valueSerializedAsBE = Hex.decode("0001");
         byte[] conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         long obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
+        assertArrayEquals(valueSerializedAsBE, conversion);
         assertEquals(value, obtainedValue);
 
         value = 255L;
+        valueSerializedAsBE = Hex.decode("00FF");
         conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
+        assertArrayEquals(valueSerializedAsBE, conversion);
         assertEquals(value, obtainedValue);
 
         value = 256L;
+        valueSerializedAsBE = Hex.decode("0100");
         conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
+        assertArrayEquals(valueSerializedAsBE, conversion);
         assertEquals(value, obtainedValue);
 
         value = 65535L;
+        valueSerializedAsBE = Hex.decode("FFFF");
         conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
+        assertArrayEquals(valueSerializedAsBE, conversion);
         assertEquals(value, obtainedValue);
     }
 

--- a/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
@@ -116,45 +116,29 @@ public class UtilsTest {
     public void unsignedLongToByteArrayLE_twoBytes() {
         final int numBytes = 2;
 
-        long valueInBE = 1L;
-        long valueInLE = 256;
-        byte[] conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
-        byte[] reversed = Utils.reverseBytes(conversion);
-        long obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
-        long obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        long value = 1L;
+        byte[] valueSerializedAsLE = Hex.decode("0100");
+        byte[] conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
-        assertEquals(valueInLE, obtainedValueInLE);
-        assertEquals(valueInBE, obtainedValueInBE);
+        assertArrayEquals(valueSerializedAsLE, conversion);
 
-        valueInBE = 255L;
-        valueInLE = 65_280;
-        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
-        reversed = Utils.reverseBytes(conversion);
-        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
-        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        value = 255L;
+        valueSerializedAsLE = Hex.decode("FF00");
+        conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
-        assertEquals(valueInLE, obtainedValueInLE);
-        assertEquals(valueInBE, obtainedValueInBE);
+        assertArrayEquals(valueSerializedAsLE, conversion);
 
-        valueInBE = 256L;
-        valueInLE = 1L;
-        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
-        reversed = Utils.reverseBytes(conversion);
-        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
-        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        value = 256L;
+        valueSerializedAsLE = Hex.decode("0001");;
+        conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
-        assertEquals(valueInLE, obtainedValueInLE);
-        assertEquals(valueInBE, obtainedValueInBE);
+        assertArrayEquals(valueSerializedAsLE, conversion);
 
-        valueInBE = 65_535L;
-        valueInLE = 65_535L;
-        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
-        reversed = Utils.reverseBytes(conversion);
-        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
-        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        value = 65_535L;
+        valueSerializedAsLE = Hex.decode("FFFF");;
+        conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
-        assertEquals(valueInLE, obtainedValueInLE);
-        assertEquals(valueInBE, obtainedValueInBE);
+        assertArrayEquals(valueSerializedAsLE, conversion);
     }
 
     @Test(expected = VerificationException.class)

--- a/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
@@ -137,13 +137,13 @@ public class UtilsTest {
         assertArrayEquals(valueSerializedAsLE, conversion);
 
         value = 256L;
-        valueSerializedAsLE = Hex.decode("0001");;
+        valueSerializedAsLE = Hex.decode("0001");
         conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
         assertArrayEquals(valueSerializedAsLE, conversion);
 
         value = 65_535L;
-        valueSerializedAsLE = Hex.decode("FFFF");;
+        valueSerializedAsLE = Hex.decode("FFFF");
         conversion = Utils.unsignedLongToByteArrayLE(value, numBytes);
         assertEquals(numBytes, conversion.length);
         assertArrayEquals(valueSerializedAsLE, conversion);
@@ -167,5 +167,68 @@ public class UtilsTest {
     @Test(expected = VerificationException.class)
     public void unsignedLongToByteArrayLE_negativeLength() {
         Utils.unsignedLongToByteArrayLE(260, -1);
+    }
+
+    @Test
+    public void signedLongToByteArrayLE() {
+        long value = 1L;
+        byte[] conversion = Utils.signedLongToByteArrayLE(value);
+        byte[] reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        long obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 255L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 256L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 65_535L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 65_536L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 5_000_000L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 100_000_000L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = 0L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = -100L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
+
+        value = -100_000L;
+        conversion = Utils.signedLongToByteArrayLE(value);
+        reversedConversion = Utils.reverseBytes(conversion); // Turn into BE
+        obtainedValue = new BigInteger(reversedConversion).longValue();
+        assertEquals(value, obtainedValue);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
@@ -111,4 +111,69 @@ public class UtilsTest {
     public void unsignedLongToByteArrayBE_negativeLength() {
         Utils.unsignedLongToByteArrayBE(260, -1);
     }
+
+    @Test
+    public void unsignedLongToByteArrayLE_twoBytes() {
+        final int numBytes = 2;
+
+        long valueInBE = 1L;
+        long valueInLE = 256;
+        byte[] conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
+        byte[] reversed = Utils.reverseBytes(conversion);
+        long obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
+        long obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        assertEquals(numBytes, conversion.length);
+        assertEquals(valueInLE, obtainedValueInLE);
+        assertEquals(valueInBE, obtainedValueInBE);
+
+        valueInBE = 255L;
+        valueInLE = 65_280;
+        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
+        reversed = Utils.reverseBytes(conversion);
+        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
+        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        assertEquals(numBytes, conversion.length);
+        assertEquals(valueInLE, obtainedValueInLE);
+        assertEquals(valueInBE, obtainedValueInBE);
+
+        valueInBE = 256L;
+        valueInLE = 1L;
+        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
+        reversed = Utils.reverseBytes(conversion);
+        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
+        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        assertEquals(numBytes, conversion.length);
+        assertEquals(valueInLE, obtainedValueInLE);
+        assertEquals(valueInBE, obtainedValueInBE);
+
+        valueInBE = 65_535L;
+        valueInLE = 65_535L;
+        conversion = Utils.unsignedLongToByteArrayLE(valueInBE, numBytes);
+        reversed = Utils.reverseBytes(conversion);
+        obtainedValueInLE = Long.parseLong(Hex.toHexString(conversion), 16);
+        obtainedValueInBE = Long.parseLong(Hex.toHexString(reversed), 16);
+        assertEquals(numBytes, conversion.length);
+        assertEquals(valueInLE, obtainedValueInLE);
+        assertEquals(valueInBE, obtainedValueInBE);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void unsignedLongToByteArrayLE_insufficientNumBytesOf1() {
+        Utils.unsignedLongToByteArrayLE(260, 1);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void unsignedLongToByteArrayLE_insufficientNumBytesOf2() {
+        Utils.unsignedLongToByteArrayLE(65536, 2);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void unsignedLongToByteArrayLE_negativeNumber() {
+        Utils.unsignedLongToByteArrayLE(-100, 2);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void unsignedLongToByteArrayLE_negativeLength() {
+        Utils.unsignedLongToByteArrayLE(260, -1);
+    }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/UtilsTest.java
@@ -64,51 +64,51 @@ public class UtilsTest {
     }
 
     @Test
-    public void unsignedLongToByteArray_twoBytes() {
+    public void unsignedLongToByteArrayBE_twoBytes() {
         final int numBytes = 2;
 
         long value = 1L;
-        byte[] conversion = Utils.unsignedLongToByteArray(value, numBytes);
+        byte[] conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         long obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
         assertEquals(value, obtainedValue);
 
         value = 255L;
-        conversion = Utils.unsignedLongToByteArray(value, numBytes);
+        conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
         assertEquals(value, obtainedValue);
 
         value = 256L;
-        conversion = Utils.unsignedLongToByteArray(value, numBytes);
+        conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
         assertEquals(value, obtainedValue);
 
         value = 65535L;
-        conversion = Utils.unsignedLongToByteArray(value, numBytes);
+        conversion = Utils.unsignedLongToByteArrayBE(value, numBytes);
         obtainedValue = Long.parseLong(Hex.toHexString(conversion), 16);
         assertEquals(numBytes, conversion.length);
         assertEquals(value, obtainedValue);
     }
 
     @Test(expected = VerificationException.class)
-    public void unsignedLongToByteArray_insufficientNumBytesOf1() {
-        Utils.unsignedLongToByteArray(260, 1);
+    public void unsignedLongToByteArrayBE_insufficientNumBytesOf1() {
+        Utils.unsignedLongToByteArrayBE(260, 1);
     }
 
     @Test(expected = VerificationException.class)
-    public void unsignedLongToByteArray_insufficientNumBytesOf2() {
-        Utils.unsignedLongToByteArray(65536, 2);
+    public void unsignedLongToByteArrayBE_insufficientNumBytesOf2() {
+        Utils.unsignedLongToByteArrayBE(65536, 2);
     }
 
     @Test(expected = VerificationException.class)
-    public void unsignedLongToByteArray_negativeNumber() {
-        Utils.unsignedLongToByteArray(-100, 2);
+    public void unsignedLongToByteArrayBE_negativeNumber() {
+        Utils.unsignedLongToByteArrayBE(-100, 2);
     }
 
     @Test(expected = VerificationException.class)
-    public void unsignedLongToByteArray_negativeLength() {
-        Utils.unsignedLongToByteArray(260, -1);
+    public void unsignedLongToByteArrayBE_negativeLength() {
+        Utils.unsignedLongToByteArrayBE(260, -1);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -330,7 +330,7 @@ public class ErpFederationRedeemScriptParserTest {
         int expectedCsvValueLength = hasDeprecatedFormat ? 2 : BigInteger.valueOf(csvValue).toByteArray().length;
         byte[] serializedCsvValue = hasDeprecatedFormat ?
             Utils.unsignedLongToByteArrayBE(csvValue, expectedCsvValueLength) :
-            Utils.reverseBytes(BigInteger.valueOf(csvValue).toByteArray());
+            Utils.signedLongToByteArrayLE(csvValue);
 
         byte[] script = erpRedeemScript.getProgram();
         Assert.assertTrue(script.length > 0);

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -67,19 +67,13 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 300L;
 
-        Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScriptDeprecated(
-            defaultFedBtcECKeyList,
-            erpFedBtcECKeyList,
-            csvValue
-        );
-
-        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
 
-        Assert.assertEquals(expectedErpRedeemScript, obtainedRedeemScript);
+        validateErpRedeemScript(erpRedeemScript, csvValue, true);
     }
 
     @Test(expected = VerificationException.class)
@@ -121,24 +115,13 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
-    @Test(expected = VerificationException.class)
-    public void createErpRedeemScriptDeprecated_csv_above_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
-
-        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue
-        );
-    }
-
     @Test
-    public void createErpRedeemScriptDeprecated_csv_exact_max_value() {
+    public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
+
+        // For a value that only uses 1 byte it should add leading zeroes to complete 2 bytes
+        long csvValue = 20L;
 
         Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
@@ -146,28 +129,7 @@ public class ErpFederationRedeemScriptParserTest {
             csvValue
         );
 
-        validateErpRedeemScript(
-            erpRedeemScript,
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            false
-        );
-    }
-
-    @Test(expected = VerificationException.class)
-    public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-
-        // For a value that only uses 1 byte it should fail
-        long csvValue = 20L;
-
-        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue
-        );
+        validateErpRedeemScript(erpRedeemScript, csvValue, true);
     }
 
     @Test
@@ -176,19 +138,13 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 300L;
 
-        Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
-            defaultFedBtcECKeyList,
-            erpFedBtcECKeyList,
-            csvValue
-        );
-
-        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
 
-        Assert.assertEquals(expectedErpRedeemScript, obtainedRedeemScript);
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
     @Test(expected = VerificationException.class)
@@ -218,10 +174,10 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_csv_below_minimum() {
+    public void createErpRedeemScript_csv_negative_value() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = ErpFederationRedeemScriptParser.MIN_CSV_VALUE - 1;
+        Long csvValue = -100L;
 
         ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -231,10 +187,10 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_csv_above_max_value() {
+    public void createErpRedeemScript_csv_zero_value() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
+        Long csvValue = 0L;
 
         ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -244,60 +200,108 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test
-    public void createErpRedeemScript_csv_exact_min_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        long csvValue = ErpFederationRedeemScriptParser.MIN_CSV_VALUE;
-
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue
-        );
-
-        validateErpRedeemScript(
-            erpRedeemScript,
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            true
-        );
-    }
-
-    @Test
-    public void createErpRedeemScript_csv_exact_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
-
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue
-        );
-
-        validateErpRedeemScript(
-            erpRedeemScript,
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            true
-        );
-    }
-
-    @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-
-        // For a value that only uses 1 byte it should fail
         long csvValue = 20L;
 
-        ErpFederationRedeemScriptParser.createErpRedeemScript(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_two_bytes_long() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 500L;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_two_bytes_long_including_sign() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 130; // Any value above 127 needs an extra byte to indicate the sign
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_three_bytes_long() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 100_000L;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_three_bytes_long_including_sign() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 33_000L; // Any value above 32_767 needs an extra byte to indicate the sign
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_four_bytes_long() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 10_000_000L;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_four_bytes_long_including_sign() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = 8_400_000L; // Any value above 8_388_607 needs an extra byte to indicate the sign
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
     @Test
@@ -320,14 +324,13 @@ public class ErpFederationRedeemScriptParserTest {
 
     private void validateErpRedeemScript(
         Script erpRedeemScript,
-        Script defaultFederationRedeemScript,
-        Script erpFederationRedeemScript,
         Long csvValue,
-        boolean useLEEncoding) {
+        boolean hasDeprecatedFormat) {
 
-        byte[] serializedCsvValue = useLEEncoding ?
-            Utils.unsignedLongToByteArrayLE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH) :
-            Utils.unsignedLongToByteArrayBE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
+        int expectedCsvValueLength = hasDeprecatedFormat ? 2 : BigInteger.valueOf(csvValue).toByteArray().length;
+        byte[] serializedCsvValue = hasDeprecatedFormat ?
+            Utils.unsignedLongToByteArrayBE(csvValue, expectedCsvValueLength) :
+            Utils.reverseBytes(BigInteger.valueOf(csvValue).toByteArray());
 
         byte[] script = erpRedeemScript.getProgram();
         Assert.assertTrue(script.length > 0);
@@ -338,10 +341,11 @@ public class ErpFederationRedeemScriptParserTest {
         Assert.assertEquals(ScriptOpCodes.OP_NOTIF, script[index++]);
 
         // Next byte should equal M, from an M/N multisig
-        Assert.assertEquals(defaultFederationRedeemScript.getChunks().get(0).opcode, script[index++]);
+        int m = defaultFedBtcECKeyList.size() / 2 + 1;
+        Assert.assertEquals(ScriptOpCodes.getOpCode(String.valueOf(m)), script[index++]);
 
         // Assert public keys
-        for (BtcECKey key: defaultFedBtcECKeyList) {
+        for (BtcECKey key : defaultFedBtcECKeyList) {
             byte[] pubkey = key.getPubKey();
             Assert.assertEquals(pubkey.length, script[index++]);
             for (int pkIndex = 0; pkIndex < pubkey.length; pkIndex++) {
@@ -350,16 +354,17 @@ public class ErpFederationRedeemScriptParserTest {
         }
 
         // Next byte should equal N, from an M/N multisig
-        Assert.assertEquals(defaultFederationRedeemScript.getChunks().get(defaultFederationRedeemScript.getChunks().size() - 2).opcode, script[index++]);
+        int n = defaultFedBtcECKeyList.size();
+        Assert.assertEquals(ScriptOpCodes.getOpCode(String.valueOf(n)), script[index++]);
 
         // Next byte should equal OP_ELSE
         Assert.assertEquals(ScriptOpCodes.OP_ELSE, script[index++]);
 
         // Next byte should equal csv value length
-        Assert.assertEquals(ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH, script[index++]);
+        Assert.assertEquals(expectedCsvValueLength, script[index++]);
 
         // Next bytes should equal the csv value in bytes
-        for (int i = 0; i < ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH; i++) {
+        for (int i = 0; i < expectedCsvValueLength; i++) {
             Assert.assertEquals(serializedCsvValue[i], script[index++]);
         }
 
@@ -367,7 +372,8 @@ public class ErpFederationRedeemScriptParserTest {
         Assert.assertEquals(ScriptOpCodes.OP_DROP, script[index++]);
 
         // Next byte should equal M, from an M/N multisig
-        Assert.assertEquals(erpFederationRedeemScript.getChunks().get(0).opcode, script[index++]);
+        m = erpFedBtcECKeyList.size() / 2 + 1;
+        Assert.assertEquals(ScriptOpCodes.getOpCode(String.valueOf(m)), script[index++]);
 
         for (BtcECKey key: erpFedBtcECKeyList) {
             byte[] pubkey = key.getPubKey();
@@ -378,7 +384,8 @@ public class ErpFederationRedeemScriptParserTest {
         }
 
         // Next byte should equal N, from an M/N multisig
-        Assert.assertEquals(erpFederationRedeemScript.getChunks().get(erpFederationRedeemScript.getChunks().size() - 2).opcode, script[index++]);
+        n = erpFedBtcECKeyList.size();
+        Assert.assertEquals(ScriptOpCodes.getOpCode(String.valueOf(n)), script[index++]);
 
         Assert.assertEquals(ScriptOpCodes.OP_ENDIF, script[index++]);
         Assert.assertEquals(Integer.valueOf(ScriptOpCodes.OP_CHECKMULTISIG).byteValue(), script[index++]);

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -128,18 +128,19 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
-    @Test(expected = VerificationException.class)
+    @Test
     public void createErpRedeemScriptDeprecated_csv_exact_max_value() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
 
-        // Should fail since the max value is larger than 2 bytes
-        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, true);
     }
 
     @Test
@@ -299,19 +300,18 @@ public class ErpFederationRedeemScriptParserTest {
         validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
-    @Test
+    @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_three_bytes_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         long csvValue = 100_000L;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        // Should fail since this value is above the max value
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
-
-        validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -201,7 +201,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript,
         Long csvValue) {
 
-        byte[] parsedCsvValue = Utils.unsignedLongToByteArray(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
+        byte[] parsedCsvValue = Utils.unsignedLongToByteArrayBE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
 
         byte[] script = erpRedeemScript.getProgram();
         Assert.assertTrue(script.length > 0);

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -115,6 +115,33 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScriptDeprecated_csv_above_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScriptDeprecated_csv_exact_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
+
+        // Should fail since the max value is larger than 2 bytes
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
     @Test
     public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
@@ -199,6 +226,34 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScript_csv_above_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_exact_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(erpRedeemScript, csvValue, false);
+    }
+
     @Test
     public void createErpRedeemScript_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
@@ -274,34 +329,32 @@ public class ErpFederationRedeemScriptParserTest {
         validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
-    @Test
+    @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_four_bytes_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         long csvValue = 10_000_000L;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        // Should fail since this value is above the max value
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
-
-        validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
-    @Test
+    @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_four_bytes_long_including_sign() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         long csvValue = 8_400_000L; // Any value above 8_388_607 needs an extra byte to indicate the sign
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        // Should fail since this value is above the max value
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
         );
-
-        validateErpRedeemScript(erpRedeemScript, csvValue, false);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -62,12 +62,12 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test
-    public void createErpRedeemScript() {
+    public void createErpRedeemScriptDeprecated() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 200L;
 
-        Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScriptDeprecated(
             defaultFedBtcECKeyList,
             erpFedBtcECKeyList,
             csvValue
@@ -83,7 +83,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_invalidDefaultFederationRedeemScript() {
+    public void createErpRedeemScriptDeprecated_invalidDefaultFederationRedeemScript() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 200L;
@@ -96,7 +96,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_invalidErpFederationRedeemScript() {
+    public void createErpRedeemScriptDeprecated_invalidErpFederationRedeemScript() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 200L;
@@ -109,7 +109,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_csv_below_zero() {
+    public void createErpRedeemScriptDeprecated_csv_below_zero() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = -200L;
@@ -122,7 +122,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_csv_above_max_value() {
+    public void createErpRedeemScriptDeprecated_csv_above_max_value() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
@@ -135,7 +135,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test
-    public void createErpRedeemScript_csv_exact_max_value() {
+    public void createErpRedeemScriptDeprecated_csv_exact_max_value() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
@@ -150,12 +150,13 @@ public class ErpFederationRedeemScriptParserTest {
             erpRedeemScript,
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
-            csvValue
+            csvValue,
+            false
         );
     }
 
     @Test
-    public void createErpRedeemScript_csv_value_one_byte_long() {
+    public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
 
@@ -173,7 +174,126 @@ public class ErpFederationRedeemScriptParserTest {
             erpRedeemScript,
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
+            csvValue,
+            false
+        );
+    }
+
+    @Test
+    public void createErpRedeemScript() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = 200L;
+
+        Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+            defaultFedBtcECKeyList,
+            erpFedBtcECKeyList,
             csvValue
+        );
+
+        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        Assert.assertEquals(expectedErpRedeemScript, obtainedRedeemScript);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScript_invalidDefaultFederationRedeemScript() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = 200L;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScript_invalidErpFederationRedeemScript() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = 200L;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScript_csv_below_zero() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = -200L;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test(expected = VerificationException.class)
+    public void createErpRedeemScript_csv_above_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
+
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_exact_max_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(
+            erpRedeemScript,
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue,
+            true
+        );
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_value_one_byte_long() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+
+        // For a value that only uses 1 byte,
+        // it should add an extra byte with value 0 to complete 2 bytes length
+        long csvValue = 20L;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(
+            erpRedeemScript,
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue,
+            true
         );
     }
 
@@ -199,9 +319,12 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpRedeemScript,
         Script defaultFederationRedeemScript,
         Script erpFederationRedeemScript,
-        Long csvValue) {
+        Long csvValue,
+        boolean useLEEncoding) {
 
-        byte[] parsedCsvValue = Utils.unsignedLongToByteArrayBE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
+        byte[] serializedCsvValue = useLEEncoding ?
+            Utils.unsignedLongToByteArrayLE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH) :
+            Utils.unsignedLongToByteArrayBE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
 
         byte[] script = erpRedeemScript.getProgram();
         Assert.assertTrue(script.length > 0);
@@ -234,7 +357,7 @@ public class ErpFederationRedeemScriptParserTest {
 
         // Next bytes should equal the csv value in bytes
         for (int i = 0; i < ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH; i++) {
-            Assert.assertEquals(parsedCsvValue[i], script[index++]);
+            Assert.assertEquals(serializedCsvValue[i], script[index++]);
         }
 
         Assert.assertEquals(Integer.valueOf(ScriptOpCodes.OP_CHECKSEQUENCEVERIFY).byteValue(), script[index++]);

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -73,7 +73,7 @@ public class ErpFederationRedeemScriptParserTest {
             csvValue
         );
 
-        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -88,7 +88,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 200L;
 
-        ErpFederationRedeemScriptParser.createErpRedeemScript(
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -101,7 +101,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(erpFedBtcECKeyList);
         Long csvValue = 200L;
 
-        ErpFederationRedeemScriptParser.createErpRedeemScript(
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -114,7 +114,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = -200L;
 
-        ErpFederationRedeemScriptParser.createErpRedeemScript(
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -127,7 +127,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
 
-        ErpFederationRedeemScriptParser.createErpRedeemScript(
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -140,7 +140,7 @@ public class ErpFederationRedeemScriptParserTest {
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
         long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
@@ -163,7 +163,7 @@ public class ErpFederationRedeemScriptParserTest {
         // it should add an extra byte with value 0 to complete 2 bytes length
         long csvValue = 20L;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -65,7 +65,7 @@ public class ErpFederationRedeemScriptParserTest {
     public void createErpRedeemScriptDeprecated() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
+        Long csvValue = 300L;
 
         Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScriptDeprecated(
             defaultFedBtcECKeyList,
@@ -155,27 +155,18 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
-    @Test
+    @Test(expected = VerificationException.class)
     public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
 
-        // For a value that only uses 1 byte,
-        // it should add an extra byte with value 0 to complete 2 bytes length
+        // For a value that only uses 1 byte it should fail
         long csvValue = 20L;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
+        ErpFederationRedeemScriptParser.createErpRedeemScriptDeprecated(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
-        );
-
-        validateErpRedeemScript(
-            erpRedeemScript,
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            false
         );
     }
 
@@ -183,7 +174,7 @@ public class ErpFederationRedeemScriptParserTest {
     public void createErpRedeemScript() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
+        Long csvValue = 300L;
 
         Script expectedErpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
@@ -204,7 +195,7 @@ public class ErpFederationRedeemScriptParserTest {
     public void createErpRedeemScript_invalidDefaultFederationRedeemScript() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
+        Long csvValue = 300L;
 
         ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -217,7 +208,7 @@ public class ErpFederationRedeemScriptParserTest {
     public void createErpRedeemScript_invalidErpFederationRedeemScript() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
+        Long csvValue = 300L;
 
         ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -227,10 +218,10 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test(expected = VerificationException.class)
-    public void createErpRedeemScript_csv_below_zero() {
+    public void createErpRedeemScript_csv_below_minimum() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = -200L;
+        Long csvValue = ErpFederationRedeemScriptParser.MIN_CSV_VALUE - 1;
 
         ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
@@ -249,6 +240,27 @@ public class ErpFederationRedeemScriptParserTest {
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
+        );
+    }
+
+    @Test
+    public void createErpRedeemScript_csv_exact_min_value() {
+        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
+        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
+        long csvValue = ErpFederationRedeemScriptParser.MIN_CSV_VALUE;
+
+        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue
+        );
+
+        validateErpRedeemScript(
+            erpRedeemScript,
+            defaultFederationRedeemScript,
+            erpFederationRedeemScript,
+            csvValue,
+            true
         );
     }
 
@@ -273,27 +285,18 @@ public class ErpFederationRedeemScriptParserTest {
         );
     }
 
-    @Test
+    @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_one_byte_long() {
         Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
         Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
 
-        // For a value that only uses 1 byte,
-        // it should add an extra byte with value 0 to complete 2 bytes length
+        // For a value that only uses 1 byte it should fail
         long csvValue = 20L;
 
-        Script erpRedeemScript = ErpFederationRedeemScriptParser.createErpRedeemScript(
+        ErpFederationRedeemScriptParser.createErpRedeemScript(
             defaultFederationRedeemScript,
             erpFederationRedeemScript,
             csvValue
-        );
-
-        validateErpRedeemScript(
-            erpRedeemScript,
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            true
         );
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
@@ -63,30 +63,6 @@ public class FastBridgeErpRedeemScriptParserTest {
     }
 
     @Test
-    public void createFastBridgeErpRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-
-        Script expectedErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
-            defaultFedBtcECKeyList,
-            erpFedBtcECKeyList,
-            csvValue,
-            derivationArgumentsHash.getBytes()
-        );
-
-        Script obtainedRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            derivationArgumentsHash
-        );
-
-        Assert.assertEquals(expectedErpRedeemScript, obtainedRedeemScript);
-    }
-
-    @Test
     public void createFastBridgeErpRedeemScript_from_Erp_redeem_script() {
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
@@ -109,36 +85,6 @@ public class FastBridgeErpRedeemScriptParserTest {
         );
 
         Assert.assertEquals(expectedRedeemScript, obtainedRedeemScript);
-    }
-
-    @Test(expected = VerificationException.class)
-    public void createFastBridgeErpRedeemScript_invalidDefaultFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-
-        FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            derivationArgumentsHash
-        );
-    }
-
-    @Test(expected = VerificationException.class)
-    public void createFastBridgeErpRedeemScript_invalidErpFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultFedBtcECKeyList);
-        Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(erpFedBtcECKeyList);
-        Long csvValue = 200L;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-
-        FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            defaultFederationRedeemScript,
-            erpFederationRedeemScript,
-            csvValue,
-            derivationArgumentsHash
-        );
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -2,6 +2,7 @@ package co.rsk.bitcoinj.script;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
 import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.math.BigInteger;
@@ -177,6 +178,17 @@ public class RedeemScriptParserFactoryTest {
     public void create_RedeemScriptParser_object_from_custom_redeem_script_insufficient_chunks() {
         Script redeemScript = new Script(new byte[2]);
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+
+        Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
+        Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());
+    }
+
+    @Test
+    public void create_RedeemScriptParser_object_from_hardcoded_testnet_redeem_script() {
+        final byte[] ERP_TESTNET_REDEEM_SCRIPT_BYTES = Utils.HEX.decode("6453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f42102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a0921039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb955670300cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368ae");
+        Script erpTestnetRedeemScript = new Script(ERP_TESTNET_REDEEM_SCRIPT_BYTES);
+
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(erpTestnetRedeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
         Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
@@ -119,7 +119,7 @@ public class RedeemScriptUtils {
                 throw new VerificationException("Provided csv value is smaller than 0");
             }
 
-            parsedCsvValue = Utils.unsignedLongToByteArray(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
+            parsedCsvValue = Utils.unsignedLongToByteArrayBE(csvValue, ErpFederationRedeemScriptParser.CSV_SERIALIZED_LENGTH);
         }
 
         ScriptBuilder scriptBuilder = new ScriptBuilder();

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
@@ -89,7 +89,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_small_csv_value() {
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_one_byte_csv_value() {
         Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
             erpFedBtcECKeyList,
@@ -100,36 +100,69 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_max_csv_value() {
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_two_bytes_csv_value() {
         Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
             erpFedBtcECKeyList,
-            ErpFederationRedeemScriptParser.MAX_CSV_VALUE
+            500L
         );
 
         Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_invalid_small_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScriptWithoutCsvValueValidation(
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_two_bytes_including_sign_csv_value() {
+        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
             erpFedBtcECKeyList,
-            10L
+            130L // Any value above 127 needs an extra byte to indicate the sign
         );
 
-        Assert.assertFalse(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
+        Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_invalid_large_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScriptWithoutCsvValueValidation(
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_three_bytes_csv_value() {
+        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultFedBtcECKeyList,
             erpFedBtcECKeyList,
-            1_000_000L
+            100_000L
         );
 
-        Assert.assertFalse(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
+        Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_three_bytes_including_sign_csv_value() {
+        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+            defaultFedBtcECKeyList,
+            erpFedBtcECKeyList,
+            33_000L // Any value above 32_767 needs an extra byte to indicate the sign
+        );
+
+        Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_four_bytes_csv_value() {
+        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+            defaultFedBtcECKeyList,
+            erpFedBtcECKeyList,
+            10_000_000L
+        );
+
+        Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasErpRedeemScriptStructure_erp_fed_redeem_script_four_bytes_including_sign_csv_value() {
+        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+            defaultFedBtcECKeyList,
+            erpFedBtcECKeyList,
+            8_400_000L // Any value above 8_388_607 needs an extra byte to indicate the sign
+        );
+
+        Assert.assertTrue(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
     }
 
     @Test


### PR DESCRIPTION
- Current implementation of `createERPRedeemScript` method was using BE encoding. This method was renamed to `createERPRedeemScriptDeprecated` to be used from rskj pre network upgrade.
- Created a new method `createERPRedeemScript` that uses LE encoding
- Establish a minimum value for the csv field, to ensure that 2 bytes are used for the serialization. Bitcoin nodes will reject a transaction with unnecessary 0s
- Updated version number