### PR TITLE
Segwit poc

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/core/BtcECKey.java
+++ b/src/main/java/co/rsk/bitcoinj/core/BtcECKey.java
@@ -432,7 +432,7 @@ public class BtcECKey {
     /** Gets the hash160 form of the public key (as seen in addresses). */
     public byte[] getPubKeyHash() {
         if (pubKeyHash == null)
-            pubKeyHash = Utils.sha256hash160(this.pub.getEncoded());
+            pubKeyHash = Utils.hash160(this.pub.getEncoded());
         return pubKeyHash;
     }
 

--- a/src/main/java/co/rsk/bitcoinj/core/Utils.java
+++ b/src/main/java/co/rsk/bitcoinj/core/Utils.java
@@ -267,11 +267,19 @@ public class Utils {
      */
     public static byte[] sha256hash160(byte[] input) {
         byte[] sha256 = Sha256Hash.hash(input);
+        return hash160(sha256);
+    }
+
+    public static byte[] hash160(byte[] input) {
+        return digestRipeMd160(Sha256Hash.hash(input));
+    }
+
+    public static byte[] digestRipeMd160(byte[] sha256) {
         RIPEMD160Digest digest = new RIPEMD160Digest();
         digest.update(sha256, 0, sha256.length);
-        byte[] out = new byte[20];
-        digest.doFinal(out, 0);
-        return out;
+        byte[] ripmemdHash = new byte[20];
+        digest.doFinal(ripmemdHash, 0);
+        return ripmemdHash;
     }
 
     /**

--- a/src/main/java/co/rsk/bitcoinj/core/Utils.java
+++ b/src/main/java/co/rsk/bitcoinj/core/Utils.java
@@ -263,12 +263,8 @@ public class Utils {
     }
 
     /**
-     * Calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
+     * Hash160 calculates RIPEMD160(SHA256(input)). This is used in Address calculations.
      */
-    public static byte[] sha256hash160(byte[] input) {
-        byte[] sha256 = Sha256Hash.hash(input);
-        return hash160(sha256);
-    }
 
     public static byte[] hash160(byte[] input) {
         return digestRipeMd160(Sha256Hash.hash(input));
@@ -277,9 +273,9 @@ public class Utils {
     public static byte[] digestRipeMd160(byte[] sha256) {
         RIPEMD160Digest digest = new RIPEMD160Digest();
         digest.update(sha256, 0, sha256.length);
-        byte[] ripmemdHash = new byte[20];
-        digest.doFinal(ripmemdHash, 0);
-        return ripmemdHash;
+        byte[] ripemdHash = new byte[20];
+        digest.doFinal(ripemdHash, 0);
+        return ripemdHash;
     }
 
     /**

--- a/src/main/java/co/rsk/bitcoinj/crypto/DeterministicKey.java
+++ b/src/main/java/co/rsk/bitcoinj/crypto/DeterministicKey.java
@@ -212,7 +212,7 @@ public class DeterministicKey extends BtcECKey {
      * Returns RIPE-MD160(SHA256(pub key bytes)).
      */
     public byte[] getIdentifier() {
-        return Utils.sha256hash160(getPubKey());
+        return Utils.hash160(getPubKey());
     }
 
     /** Returns the first 32 bits of the result of {@link #getIdentifier()}. */

--- a/src/main/java/co/rsk/bitcoinj/script/Script.java
+++ b/src/main/java/co/rsk/bitcoinj/script/Script.java
@@ -325,7 +325,7 @@ public class Script {
      */
     @Deprecated
     public Address getFromAddress(NetworkParameters params) throws ScriptException {
-        return new Address(params, Utils.sha256hash160(getPubKey()));
+        return new Address(params, Utils.hash160(getPubKey()));
     }
 
     /**
@@ -1263,7 +1263,7 @@ public class Script {
                 case OP_HASH160:
                     if (stack.size() < 1)
                         throw new ScriptException("Attempted OP_HASH160 on an empty stack");
-                    stack.add(Utils.sha256hash160(stack.pollLast()));
+                    stack.add(Utils.hash160(stack.pollLast()));
                     break;
                 case OP_HASH256:
                     if (stack.size() < 1)

--- a/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
@@ -17,6 +17,7 @@
 package co.rsk.bitcoinj.script;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Sha256Hash;
 import com.google.common.collect.Lists;
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -413,6 +414,23 @@ public class ScriptBuilder {
     public static Script createP2SHOutputScript(Script redeemScript) {
         byte[] hash = Utils.sha256hash160(redeemScript.getProgram());
         return ScriptBuilder.createP2SHOutputScript(hash);
+    }
+
+    /**
+     * Creates a P2SH-P2WSH scriptPubKey for the given redeem script.
+     */
+    public static Script createP2SHP2WSHOutputScript(Script redeemScript) {
+
+        byte[] redeemScriptHash = Sha256Hash.hash(redeemScript.getProgram());
+
+        Script witnessScript = new ScriptBuilder()
+            .number(ScriptOpCodes.OP_0)
+            .data(redeemScriptHash)
+            .build();
+
+        byte[] outputScriptHash = Utils.hash160(witnessScript.getProgram());
+
+        return ScriptBuilder.createP2SHOutputScript(outputScriptHash);
     }
 
     /**

--- a/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
@@ -412,7 +412,7 @@ public class ScriptBuilder {
      * Creates a scriptPubKey for the given redeem script.
      */
     public static Script createP2SHOutputScript(Script redeemScript) {
-        byte[] hash = Utils.sha256hash160(redeemScript.getProgram());
+        byte[] hash = Utils.hash160(redeemScript.getProgram());
         return ScriptBuilder.createP2SHOutputScript(hash);
     }
 
@@ -420,16 +420,12 @@ public class ScriptBuilder {
      * Creates a P2SH-P2WSH scriptPubKey for the given redeem script.
      */
     public static Script createP2SHP2WSHOutputScript(Script redeemScript) {
-
         byte[] redeemScriptHash = Sha256Hash.hash(redeemScript.getProgram());
-
         Script witnessScript = new ScriptBuilder()
             .number(ScriptOpCodes.OP_0)
             .data(redeemScriptHash)
             .build();
-
         byte[] outputScriptHash = Utils.hash160(witnessScript.getProgram());
-
         return ScriptBuilder.createP2SHOutputScript(outputScriptHash);
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/P2shP2WSHScriptTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2shP2WSHScriptTest.java
@@ -1,0 +1,38 @@
+package co.rsk.bitcoinj.script;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+import org.spongycastle.util.encoders.Hex;
+
+public class P2shP2WSHScriptTest {
+
+    @Test
+    public void getAddressFromP2shP2wshScript() {
+        List<BtcECKey> keys = Arrays.asList(new String[]{
+            "027de2af71862e0c64bf0ec5a66e3abc3b01fc57877802e6a6a81f6ea1d3561007",
+            "02d9c67fef9f8d0707cbcca195eb5f26c6a65da6ca2d6130645c434bb924063856",
+            "0346f033b8652a17d319d3ecbbbf20fd2cd663a6548173b9419d8228eef095012e"
+        }).stream().map(k -> BtcECKey.fromPublicOnly(Hex.decode(k))).collect(Collectors.toList());
+
+        Script redeemNuestro = new ScriptBuilder().createRedeemScript(
+            keys.size() / 2 + 1,
+            keys
+        );
+
+        Script p2SHP2WSHOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(redeemNuestro);
+        Address segwitAddress = Address.fromP2SHScript(
+            NetworkParameters.fromID(NetworkParameters.ID_TESTNET),
+            p2SHP2WSHOutputScript
+        );
+
+        Assert.assertEquals("2NCQHJJuG2iQjN2Be3QYXwWvFgS6AZ4MEkL", segwitAddress.toBase58());
+        // https://mempool.space/testnet/tx/1744459aeaf7369aadc9fc40de9ab2bf575b14e35029b35a7ee4bbd3de65af7f
+    }
+
+}

--- a/src/test/java/co/rsk/bitcoinj/script/P2shP2wshScriptTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2shP2wshScriptTest.java
@@ -10,7 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
-public class P2shP2WSHScriptTest {
+public class P2shP2wshScriptTest {
 
     @Test
     public void getAddressFromP2shP2wshScript() {
@@ -20,15 +20,15 @@ public class P2shP2WSHScriptTest {
             "0346f033b8652a17d319d3ecbbbf20fd2cd663a6548173b9419d8228eef095012e"
         }).stream().map(k -> BtcECKey.fromPublicOnly(Hex.decode(k))).collect(Collectors.toList());
 
-        Script redeemNuestro = new ScriptBuilder().createRedeemScript(
+        Script redeemScript = new ScriptBuilder().createRedeemScript(
             keys.size() / 2 + 1,
             keys
         );
 
-        Script p2SHP2WSHOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(redeemNuestro);
+        Script p2shP2wshOutputScript = ScriptBuilder.createP2SHP2WSHOutputScript(redeemScript);
         Address segwitAddress = Address.fromP2SHScript(
             NetworkParameters.fromID(NetworkParameters.ID_TESTNET),
-            p2SHP2WSHOutputScript
+            p2shP2wshOutputScript
         );
 
         Assert.assertEquals("2NCQHJJuG2iQjN2Be3QYXwWvFgS6AZ4MEkL", segwitAddress.toBase58());

--- a/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
@@ -107,7 +107,7 @@ public class ScriptTest {
         byte[] sigProgBytes = Hex.decode(sigProg);
         Script script = new Script(sigProgBytes);
         // Test we can extract the from address.
-        byte[] hash160 = Utils.sha256hash160(script.getPubKey());
+        byte[] hash160 = Utils.hash160(script.getPubKey());
         Address a = new Address(PARAMS, hash160);
         assertEquals("mkFQohBpy2HDXrCwyMrYL5RtfrmeiuuPY2", a.toString());
     }


### PR DESCRIPTION
This branch was created to make the change the fed address into a segwit-compatible one.
For now,
1. Create a new method (called _createP2SHP2WSHOutputScript_) in ScriptBuilder class that creates the output script for a P2SH-P2WSH
2. Add a test to compare our calculation for a P2SH-P2WSH address against the one obtained with electrum
3. Rename existing function `sha256hash160` to simply `hash160` and replace it where needed. This makes sense since _hash160_ by definition first makes a _sha256_ encryption.