### PR TITLE
Sign with witness fed

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/core/BtcTransaction.java
+++ b/src/main/java/co/rsk/bitcoinj/core/BtcTransaction.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongycastle.crypto.params.KeyParameter;
 
 import javax.annotation.Nullable;
 import java.io.*;
@@ -104,7 +105,6 @@ public class BtcTransaction extends ChildMessage {
     private ArrayList<TransactionInput> inputs;
     private ArrayList<TransactionOutput> outputs;
     private ArrayList<TransactionWitness> witnesses;
-
 
     private long lockTime;
 
@@ -1165,6 +1165,112 @@ public class BtcTransaction extends ChildMessage {
             throw new RuntimeException(e);  // Cannot happen.
         }
     }
+
+    public synchronized Sha256Hash hashForWitnessSignature(
+        int inputIndex,
+        byte[] scriptCode,
+        Coin prevValue,
+        SigHash type,
+        boolean anyoneCanPay) {
+        int sigHash = TransactionSignature.calcSigHashValue(type, anyoneCanPay);
+        return hashForWitnessSignature(inputIndex, scriptCode, prevValue, (byte) sigHash);
+    }
+
+    /**
+     * <p>Calculates a signature hash, that is, a hash of a simplified form of the transaction. How exactly the transaction
+     * is simplified is specified by the type and anyoneCanPay parameters.</p>
+     *
+     * <p>This is a low level API and when using the regular {@link Wallet} class you don't have to call this yourself.
+     * When working with more complex transaction types and contracts, it can be necessary. When signing a Witness output
+     * the scriptCode should be the script encoded into the scriptSig field, for normal transactions, it's the
+     * scriptPubKey of the output you're signing for. (See BIP143: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki)</p>
+     *
+     * @param inputIndex   input the signature is being calculated for. Tx signatures are always relative to an input.
+     * @param scriptCode   the script that should be in the given input during signing.
+     * @param prevValue    the value of the coin being spent
+     * @param type         Should be SigHash.ALL
+     * @param anyoneCanPay should be false.
+     */
+    public synchronized Sha256Hash hashForWitnessSignature(
+        int inputIndex,
+        Script scriptCode,
+        Coin prevValue,
+        SigHash type,
+        boolean anyoneCanPay) {
+        return hashForWitnessSignature(inputIndex, scriptCode.getProgram(), prevValue, type, anyoneCanPay);
+    }
+
+    public synchronized Sha256Hash hashForWitnessSignature(
+        int inputIndex,
+        byte[] scriptCode,
+        Coin prevValue,
+        byte sigHashType){
+        ByteArrayOutputStream bos = new UnsafeByteArrayOutputStream(length == UNKNOWN_LENGTH ? 256 : length + 4);
+        try {
+            byte[] hashPrevouts = new byte[32];
+            byte[] hashSequence = new byte[32];
+            byte[] hashOutputs = new byte[32];
+            int basicSigHashType = sigHashType & 0x1f;
+            boolean anyoneCanPay = (sigHashType & SigHash.ANYONECANPAY.value) == SigHash.ANYONECANPAY.value;
+            boolean signAll = (basicSigHashType != SigHash.SINGLE.value) && (basicSigHashType != SigHash.NONE.value);
+
+            if (!anyoneCanPay) {
+                ByteArrayOutputStream bosHashPrevouts = new UnsafeByteArrayOutputStream(256);
+                for (int i = 0; i < this.inputs.size(); ++i) {
+                    bosHashPrevouts.write(this.inputs.get(i).getOutpoint().getHash().getReversedBytes());
+                    uint32ToByteStreamLE(this.inputs.get(i).getOutpoint().getIndex(), bosHashPrevouts);
+                }
+                hashPrevouts = Sha256Hash.hashTwice(bosHashPrevouts.toByteArray());
+            }
+
+            if (!anyoneCanPay && signAll) {
+                ByteArrayOutputStream bosSequence = new UnsafeByteArrayOutputStream(256);
+                for (int i = 0; i < this.inputs.size(); ++i) {
+                    uint32ToByteStreamLE(this.inputs.get(i).getSequenceNumber(), bosSequence);
+                }
+                hashSequence = Sha256Hash.hashTwice(bosSequence.toByteArray());
+            }
+
+            if (signAll) {
+                ByteArrayOutputStream bosHashOutputs = new UnsafeByteArrayOutputStream(256);
+                for (int i = 0; i < this.outputs.size(); ++i) {
+                    uint64ToByteStreamLE(
+                        BigInteger.valueOf(this.outputs.get(i).getValue().getValue()),
+                        bosHashOutputs
+                    );
+                    bosHashOutputs.write(new VarInt(this.outputs.get(i).getScriptBytes().length).encode());
+                    bosHashOutputs.write(this.outputs.get(i).getScriptBytes());
+                }
+                hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
+            } else if (basicSigHashType == SigHash.SINGLE.value && inputIndex < outputs.size()) {
+                ByteArrayOutputStream bosHashOutputs = new UnsafeByteArrayOutputStream(256);
+                uint64ToByteStreamLE(
+                    BigInteger.valueOf(this.outputs.get(inputIndex).getValue().getValue()),
+                    bosHashOutputs
+                );
+                bosHashOutputs.write(new VarInt(this.outputs.get(inputIndex).getScriptBytes().length).encode());
+                bosHashOutputs.write(this.outputs.get(inputIndex).getScriptBytes());
+                hashOutputs = Sha256Hash.hashTwice(bosHashOutputs.toByteArray());
+            }
+            uint32ToByteStreamLE(version, bos);
+            bos.write(hashPrevouts);
+            bos.write(hashSequence);
+            bos.write(inputs.get(inputIndex).getOutpoint().getHash().getReversedBytes());
+            uint32ToByteStreamLE(inputs.get(inputIndex).getOutpoint().getIndex(), bos);
+            bos.write(new VarInt(scriptCode.length).encode());
+            bos.write(scriptCode);
+            uint64ToByteStreamLE(BigInteger.valueOf(prevValue.getValue()), bos);
+            uint32ToByteStreamLE(inputs.get(inputIndex).getSequenceNumber(), bos);
+            bos.write(hashOutputs);
+            uint32ToByteStreamLE(this.lockTime, bos);
+            uint32ToByteStreamLE(0x000000ff & sigHashType, bos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);  // Cannot happen.
+        }
+
+        return Sha256Hash.twiceOf(bos.toByteArray());
+    }
+
 
     @Override
     protected void bitcoinSerializeToStream(OutputStream stream) throws IOException {

--- a/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
+++ b/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
@@ -74,7 +74,7 @@ public class TransactionWitness {
         for (TransactionSignature signature : signatures) {
             pushes.add(signature.encodeToBitcoin());
         }
-        pushes.add(new byte[] {});
+        pushes.add(new byte[] {}); // OP_NOTIF argument. If a 0 is set it will validate against the standard keys, if a 1 is set it will validate against the emergency keys
         pushes.add(witnessScript.getProgram());
         return TransactionWitness.of(pushes);
     }

--- a/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
+++ b/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
@@ -61,8 +61,20 @@ public class TransactionWitness {
     public static TransactionWitness createWitnessScript(Script witnessScript, List<TransactionSignature> signatures) {
         List<byte[]> pushes = new ArrayList<>(signatures.size() + 2);
         pushes.add(new byte[] {});
-        for (TransactionSignature signature : signatures)
+        for (TransactionSignature signature : signatures) {
             pushes.add(signature.encodeToBitcoin());
+        }
+        pushes.add(witnessScript.getProgram());
+        return TransactionWitness.of(pushes);
+    }
+
+    public static TransactionWitness createWitnessErpScript(Script witnessScript, List<TransactionSignature> signatures) {
+        List<byte[]> pushes = new ArrayList<>(signatures.size() + 3);
+        pushes.add(new byte[] {});
+        for (TransactionSignature signature : signatures) {
+            pushes.add(signature.encodeToBitcoin());
+        }
+        pushes.add(new byte[] {});
         pushes.add(witnessScript.getProgram());
         return TransactionWitness.of(pushes);
     }

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
@@ -84,6 +84,29 @@ public class P2shErpFederationRedeemScriptParser extends StandardRedeemScriptPar
         return erpRedeemScript;
     }
 
+    public static Script createP2shP2wshErpRedeemScript(
+        Script defaultFederationRedeemScript,
+        Script erpFederationRedeemScript,
+        Long csvValue
+    ) {
+        byte[] serializedCsvValue = Utils.signedLongToByteArrayLE(csvValue);
+
+        ScriptBuilder scriptBuilder = new ScriptBuilder();
+
+        Script erpP2shP2wshRedeemScript = scriptBuilder
+            .op(ScriptOpCodes.OP_0NOTEQUAL)
+            .op(ScriptOpCodes.OP_NOTIF)
+            .addChunks(defaultFederationRedeemScript.getChunks())
+            .op(ScriptOpCodes.OP_ELSE)
+            .data(serializedCsvValue)
+            .op(ScriptOpCodes.OP_CHECKSEQUENCEVERIFY)
+            .op(ScriptOpCodes.OP_DROP)
+            .addChunks(erpFederationRedeemScript.getChunks())
+            .op(ScriptOpCodes.OP_ENDIF)
+            .build();
+        return erpP2shP2wshRedeemScript;
+    }
+
     public static boolean isP2shErpFed(List<ScriptChunk> chunks) {
         return RedeemScriptValidator.hasP2shErpRedeemScriptStructure(chunks);
     }


### PR DESCRIPTION
To sign with a p2sh-p2wsh erp fed we had to add the following functions: 
`hashForWitnessSignature`, `createWitnessErpFed` and `createP2shP2wshErpRedeemScript `.
The last function was created to avoid redeemScript internal validation checks, since with segwit an `OP_0NOTEQUAL` had to be added before the `OP_NOTIF` to make the redeemScript valid for bitcoin.