### PR TITLE
Refactor parsers integration

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -15,14 +15,10 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     public static long MAX_CSV_VALUE = 65_535L; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value
 
     public ErpFederationRedeemScriptParser(
-        ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
-            rawChunks
+            extractStandardRedeemScript(redeemScriptChunks).getChunks()
         );
         this.multiSigType = MultiSigType.ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -10,14 +10,10 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
     private static final Logger logger = LoggerFactory.getLogger(FastBridgeErpRedeemScriptParser.class);
 
     public FastBridgeErpRedeemScriptParser(
-        ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
-            rawChunks
+            extractStandardRedeemScript(redeemScriptChunks).getChunks()
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
@@ -11,14 +11,10 @@ public class FastBridgeP2shErpRedeemScriptParser extends StandardRedeemScriptPar
     private static final Logger logger = LoggerFactory.getLogger(FastBridgeP2shErpRedeemScriptParser.class);
 
     public FastBridgeP2shErpRedeemScriptParser(
-        ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
-            rawChunks
+            extractStandardRedeemScript(redeemScriptChunks).getChunks()
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_P2SH_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
@@ -12,14 +12,10 @@ public class FastBridgeRedeemScriptParser extends StandardRedeemScriptParser {
     protected final byte[] derivationHash;
 
     public FastBridgeRedeemScriptParser(
-        ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
-            redeemScriptChunks.subList(2, redeemScriptChunks.size()),
-            rawChunks
+            redeemScriptChunks.subList(2, redeemScriptChunks.size())
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_MULTISIG;
         this.derivationHash = redeemScriptChunks.get(0).data;

--- a/src/main/java/co/rsk/bitcoinj/script/NoRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NoRedeemScriptParser.java
@@ -13,19 +13,10 @@ public class NoRedeemScriptParser implements RedeemScriptParser {
     }
 
     @Override
-    public ScriptType getScriptType() {
-        return ScriptType.UNDEFINED;
-    }
-
-    @Override
     public int getM() {
         return -1;
     }
 
-    @Override
-    public int getSigInsertionIndex(Sha256Hash hash, BtcECKey signingKey) {
-        return 0;
-    }
 
     @Override
     public int findKeyInRedeem(BtcECKey key) {

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
@@ -14,14 +14,10 @@ public class P2shErpFederationRedeemScriptParser extends StandardRedeemScriptPar
     public static long MAX_CSV_VALUE = 65_535L; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value
 
     public P2shErpFederationRedeemScriptParser(
-        ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
-            rawChunks
+            extractStandardRedeemScript(redeemScriptChunks).getChunks()
         );
         this.multiSigType = MultiSigType.P2SH_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
@@ -16,19 +16,11 @@ public interface RedeemScriptParser {
         FAST_BRIDGE_P2SH_ERP_FED
     }
 
-    enum ScriptType {
-        P2SH,
-        REDEEM_SCRIPT,
-        UNDEFINED
-    }
 
     MultiSigType getMultiSigType();
 
-    ScriptType getScriptType();
 
     int getM();
-
-    int getSigInsertionIndex(Sha256Hash hash, BtcECKey signingKey);
 
     int findKeyInRedeem(BtcECKey key);
 

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -1,8 +1,6 @@
 package co.rsk.bitcoinj.script;
 
-import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Utils;
-import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,98 +25,44 @@ public class RedeemScriptParserFactory {
             return new NoRedeemScriptParser();
         }
 
-        ParseResult result = extractRedeemScriptFromChunks(chunks);
-
-        if (result == null) {
-            return new NoRedeemScriptParser();
-        }
-
-        if (FastBridgeRedeemScriptParser.isFastBridgeMultiSig(result.internalScript)) {
+        if (FastBridgeRedeemScriptParser.isFastBridgeMultiSig(chunks)) {
             logger.debug("[get] Return FastBridgeRedeemScriptParser");
             return new FastBridgeRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
-        if (StandardRedeemScriptParser.isStandardMultiSig(result.internalScript)) {
+        if (StandardRedeemScriptParser.isStandardMultiSig(chunks)) {
             logger.debug("[get] Return StandardRedeemScriptParser");
             return new StandardRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
-        if (P2shErpFederationRedeemScriptParser.isP2shErpFed(result.internalScript)) {
+        if (P2shErpFederationRedeemScriptParser.isP2shErpFed(chunks)) {
             logger.debug("[get] Return P2shErpFederationRedeemScriptParser");
             return new P2shErpFederationRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
-        if (FastBridgeP2shErpRedeemScriptParser.isFastBridgeP2shErpFed(result.internalScript)) {
+        if (FastBridgeP2shErpRedeemScriptParser.isFastBridgeP2shErpFed(chunks)) {
             logger.debug("[get] Return FastBridgeP2shErpRedeemScriptParser");
             return new FastBridgeP2shErpRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
-        if (ErpFederationRedeemScriptParser.isErpFed(result.internalScript)) {
+        if (ErpFederationRedeemScriptParser.isErpFed(chunks)) {
             logger.debug("[get] Return ErpFederationRedeemScriptParser");
             return new ErpFederationRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
-        if (FastBridgeErpRedeemScriptParser.isFastBridgeErpFed(result.internalScript)) {
+        if (FastBridgeErpRedeemScriptParser.isFastBridgeErpFed(chunks)) {
             logger.debug("[get] Return FastBridgeErpRedeemScriptParser");
             return new FastBridgeErpRedeemScriptParser(
-                result.scriptType,
-                result.internalScript,
                 chunks
             );
         }
 
         logger.debug("[get] Return NoRedeemScriptParser");
         return new NoRedeemScriptParser();
-    }
-
-    private static ParseResult extractRedeemScriptFromChunks(List<ScriptChunk> chunks) {
-        ScriptChunk lastChunk = chunks.get(chunks.size() - 1);
-        if (RedeemScriptValidator.isRedeemLikeScript(chunks)) {
-            return new ParseResult(chunks, ScriptType.REDEEM_SCRIPT);
-        }
-        if (lastChunk.data != null && lastChunk.data.length > 0) {
-            int lastByte = lastChunk.data[lastChunk.data.length - 1] & 0xff;
-            // ERP and standard (+fastBridge) finish with OP_CHECKMULTISIG and P2SHERP (+fastBridge) finish with OP_ENDIF
-            if (
-                    lastByte == ScriptOpCodes.OP_CHECKMULTISIG ||
-                    lastByte == ScriptOpCodes.OP_CHECKMULTISIGVERIFY ||
-                    lastByte == ScriptOpCodes.OP_ENDIF
-            ) {
-                ScriptParserResult result = ScriptParser.parseScriptProgram(lastChunk.data);
-                if (result.getException().isPresent()) {
-                    String message = String.format("Error trying to parse inner script. %s", result.getException().get());
-                    logger.debug("[extractRedeemScriptFromChunks] {}", message);
-                    throw new ScriptException(message);
-                }
-                return new ParseResult(result.getChunks(), ScriptType.P2SH);
-            }
-        }
-        logger.debug("[extractRedeemScriptFromChunks] Could not get redeem script from given chunks");
-        return null;
-    }
-
-    private static class ParseResult {
-        public final List<ScriptChunk> internalScript;
-        public final ScriptType scriptType;
-
-        public ParseResult(List<ScriptChunk> internalScript, ScriptType scriptType) {
-            this.internalScript = internalScript;
-            this.scriptType = scriptType;
-        }
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
@@ -1,0 +1,40 @@
+package co.rsk.bitcoinj.script;
+
+import co.rsk.bitcoinj.core.ScriptException;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RedeemScriptUtils {
+    private static final Logger logger = LoggerFactory.getLogger(RedeemScriptUtils.class);
+
+    private RedeemScriptUtils() { }
+    public static Optional<RedeemScriptParser> extractRedeemScriptParserFromInputScript(Script inputScript) {
+        List<ScriptChunk> chunks = inputScript.getChunks();
+
+        if (chunks == null || chunks.isEmpty()) {
+            return Optional.empty();
+        }
+
+        byte[] program = chunks.get(chunks.size() - 1).data;
+        if (program == null) {
+            return Optional.empty();
+        }
+
+        try {
+            Script redeemScript = new Script(program);
+            RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+            return Optional.of(redeemScriptParser);
+        } catch (ScriptException e) {
+            logger.debug(
+                "[extractRedeemScriptFromInput] Failed to extract redeem script from inputScript {}. {}",
+                inputScript,
+                e.getMessage()
+            );
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
@@ -12,7 +12,7 @@ public class RedeemScriptUtils {
     private static final Logger logger = LoggerFactory.getLogger(RedeemScriptUtils.class);
 
     private RedeemScriptUtils() { }
-    public static Optional<RedeemScriptParser> extractRedeemScriptParserFromInputScript(Script inputScript) {
+    public static Optional<Script> extractRedeemScriptFromInputScript(Script inputScript) {
         List<ScriptChunk> chunks = inputScript.getChunks();
 
         if (chunks == null || chunks.isEmpty()) {
@@ -26,8 +26,7 @@ public class RedeemScriptUtils {
 
         try {
             Script redeemScript = new Script(program);
-            RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
-            return Optional.of(redeemScriptParser);
+            return Optional.of(redeemScript);
         } catch (ScriptException e) {
             logger.debug(
                 "[extractRedeemScriptFromInput] Failed to extract redeem script from inputScript {}. {}",

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -16,18 +16,18 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void extractStandardRedeemScript_fromErpRedeemScript() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             100L
         );
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
         Script obtainedRedeemScript = ErpFederationRedeemScriptParser.extractStandardRedeemScript(
@@ -39,7 +39,7 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
         ErpFederationRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
@@ -47,10 +47,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScriptDeprecated() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -66,10 +66,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScriptDeprecated_invalidDefaultFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 200L;
@@ -83,10 +83,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScriptDeprecated_invalidErpFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 200L;
@@ -100,10 +100,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScriptDeprecated_csv_below_zero() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = -200L;
@@ -117,10 +117,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScriptDeprecated_csv_above_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
@@ -134,10 +134,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScriptDeprecated_csv_exact_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
@@ -153,10 +153,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScriptDeprecated_csv_value_one_byte_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
 
@@ -174,10 +174,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -193,10 +193,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_invalidDefaultFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -210,10 +210,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_invalidErpFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -227,10 +227,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_negative_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = -100L;
@@ -244,10 +244,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_zero_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 0L;
@@ -261,10 +261,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_above_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
@@ -278,10 +278,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript_csv_exact_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = ErpFederationRedeemScriptParser.MAX_CSV_VALUE;
@@ -297,10 +297,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript_csv_value_one_byte_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 20L;
@@ -316,10 +316,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript_csv_value_two_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 500L;
@@ -335,10 +335,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript_csv_value_two_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 130; // Any value above 127 needs an extra byte to indicate the sign
@@ -354,10 +354,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_three_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 100_000L;
@@ -372,10 +372,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void createErpRedeemScript_csv_value_three_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 33_000L; // Any value above 32_767 needs an extra byte to indicate the sign
@@ -391,10 +391,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_four_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 10_000_000L;
@@ -409,10 +409,10 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createErpRedeemScript_csv_value_four_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 8_400_000L; // Any value above 8_388_607 needs an extra byte to indicate the sign
@@ -427,7 +427,7 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void isErpFed() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L
@@ -438,7 +438,7 @@ public class ErpFederationRedeemScriptParserTest {
 
     @Test
     public void isErpFed_falseWithCustomRedeemScript() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script customRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
 

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
@@ -15,22 +15,22 @@ public class FastBridgeErpRedeemScriptParserTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void extractStandardRedeemScript_fromFastBridgeErpRedeemScript() {
         Long csvValue = 100L;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             csvValue,
             derivationArgumentsHash.getBytes()
         );
 
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
         Script obtainedRedeemScript = FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(
@@ -42,7 +42,7 @@ public class FastBridgeErpRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
         FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
@@ -50,7 +50,7 @@ public class FastBridgeErpRedeemScriptParserTest {
 
     @Test
     public void createFastBridgeErpRedeemScript_from_Erp_redeem_script() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             5063L
@@ -58,7 +58,7 @@ public class FastBridgeErpRedeemScriptParserTest {
 
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
 
-        Script expectedRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script expectedRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             5063L,
@@ -75,7 +75,7 @@ public class FastBridgeErpRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeErpFed() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L,
@@ -87,7 +87,7 @@ public class FastBridgeErpRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeErpFed_falseWithCustomRedeemScript() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script customRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys);
 
         Assert.assertFalse(FastBridgeErpRedeemScriptParser.isFastBridgeErpFed(customRedeemScript.getChunks()));

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParserTest.java
@@ -24,22 +24,22 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void extractStandardRedeemScript_fromFastBridgeP2shErpRedeemScript() {
         Long csvValue = 100L;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script fastBridgeP2shErpRedeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             csvValue,
             derivationArgumentsHash.getBytes()
         );
 
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
@@ -52,7 +52,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
@@ -61,7 +61,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Test
     public void createFastBridgeP2shErpRedeemScript_fromP2shErpRedeemScript() {
-        Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             5063L
@@ -69,7 +69,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
 
-        Script expectedRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script expectedRedeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             5063L,
@@ -86,7 +86,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeP2shErpFed() {
-        Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script fastBridgeP2shErpRedeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L,
@@ -100,7 +100,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeP2shErpFed_falseWithFastBridgeErpFed() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L,
@@ -114,7 +114,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeP2shErpFed_falseWithCustomRedeemScript() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script customRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
 

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
@@ -14,18 +14,18 @@ public class FastBridgeRedeemScriptParserTest {
 
     @Before
     public void setUp() {
-        publicKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
+        publicKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
     }
 
     @Test
     public void extractRedeemScriptFromMultiSigFastBridgeRedeemScript_fb_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             publicKeys
         );
 
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(publicKeys);
 
         Script obtainedRedeemScript = FastBridgeRedeemScriptParser.extractStandardRedeemScript(
             fastBridgeRedeemScript
@@ -36,7 +36,7 @@ public class FastBridgeRedeemScriptParserTest {
 
     @Test
     public void extractRedeemScriptFromMultiSigFastBridgeRedeemScript_std_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(publicKeys);
         Script obtainedRedeemScript = FastBridgeRedeemScriptParser.extractStandardRedeemScript(redeemScript);
 
         Assert.assertEquals(redeemScript, obtainedRedeemScript);
@@ -44,10 +44,10 @@ public class FastBridgeRedeemScriptParserTest {
 
     @Test
     public void createMultiSigFastBridgeRedeemScript_valid_parameters() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(publicKeys);
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
 
-        Script expectedFastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script expectedFastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             derivationArgumentsHash.getBytes(),
             publicKeys
         );
@@ -62,7 +62,7 @@ public class FastBridgeRedeemScriptParserTest {
     @Test(expected = VerificationException.class)
     public void createMultiSigFastBridgeRedeemScript_fb_redeem_script() {
         Sha256Hash data = Sha256Hash.of(new byte[]{1});
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data.getBytes(),
             publicKeys
         );
@@ -72,20 +72,20 @@ public class FastBridgeRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createMultiSigFastBridgeRedeemScript_null_derivation_arguments_hash() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(publicKeys);
         FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(redeemScript, null);
     }
 
     @Test(expected = VerificationException.class)
     public void createMultiSigFastBridgeRedeemScript_zero_hash_as_derivation_arguments_hash() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(publicKeys);
         FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(redeemScript, Sha256Hash.ZERO_HASH);
     }
 
     @Test
     public void getDerivationArgumentsHash_from_fast_bridge_multiSig() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             publicKeys
         );
@@ -99,7 +99,7 @@ public class FastBridgeRedeemScriptParserTest {
     @Test
     public void isFastBridgeMultisig() {
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             derivationArgumentsHash.getBytes(),
             publicKeys
         );
@@ -109,7 +109,7 @@ public class FastBridgeRedeemScriptParserTest {
 
     @Test
     public void isFastBridgeMultisig_falseWithCustomRedeemScrip() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(publicKeys);
+        Script customRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(publicKeys);
 
         Assert.assertFalse(FastBridgeRedeemScriptParser.isFastBridgeMultiSig(customRedeemScript.getChunks()));
     }

--- a/src/test/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParserTest.java
@@ -15,18 +15,18 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void extractStandardRedeemScript_fromP2shErpRedeemScript() {
-        Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             100L
         );
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
@@ -39,7 +39,7 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script standardRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
@@ -48,10 +48,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -67,10 +67,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_invalidDefaultFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -84,10 +84,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_invalidErpFederationRedeemScript() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 300L;
@@ -101,10 +101,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_negative_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = -100L;
@@ -118,10 +118,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_zero_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = 0L;
@@ -135,10 +135,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_above_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = P2shErpFederationRedeemScriptParser.MAX_CSV_VALUE + 1;
@@ -152,10 +152,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript_csv_exact_max_value() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         Long csvValue = P2shErpFederationRedeemScriptParser.MAX_CSV_VALUE;
@@ -171,10 +171,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript_csv_value_one_byte_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 20L;
@@ -190,10 +190,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript_csv_value_two_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 500L;
@@ -209,10 +209,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript_csv_value_two_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 130; // Any value above 127 needs an extra byte to indicate the sign
@@ -228,10 +228,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_value_three_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 100_000L;
@@ -246,10 +246,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void createP2shErpRedeemScript_csv_value_three_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 33_000L; // Any value above 32_767 needs an extra byte to indicate the sign
@@ -265,10 +265,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_value_four_bytes_long() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 10_000_000L;
@@ -283,10 +283,10 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test(expected = VerificationException.class)
     public void createP2shErpRedeemScript_csv_value_four_bytes_long_including_sign() {
-        Script defaultFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script defaultFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
-        Script erpFederationRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
+        Script erpFederationRedeemScript = RedeemScriptTestUtils.createStandardRedeemScript(
             emergencyRedeemScriptKeys
         );
         long csvValue = 8_400_000L; // Any value above 8_388_607 needs an extra byte to indicate the sign
@@ -301,7 +301,7 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void isP2shErpFed() {
-        Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L
@@ -312,7 +312,7 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void isErpFed_falseWithP2shErpRedeemScript() {
-        Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             200L
@@ -323,7 +323,7 @@ public class P2shErpFederationRedeemScriptParserTest {
 
     @Test
     public void isP2shErpFed_falseWithCustomRedeemScript() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+        Script customRedeemScript = RedeemScriptTestUtils.createCustomRedeemScript(
             defaultRedeemScriptKeys
         );
 

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -11,7 +11,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static co.rsk.bitcoinj.script.RedeemScriptUtils.extractRedeemScriptParserFromInputScript;
+import static co.rsk.bitcoinj.script.RedeemScriptUtils.extractRedeemScriptFromInputScript;
 
 public class RedeemScriptParserFactoryTest {
 
@@ -116,7 +116,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeRedeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
     }
@@ -131,7 +132,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, redeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
     }
@@ -150,7 +152,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, erpRedeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
     }
@@ -170,7 +173,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeErpRedeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
     }
@@ -189,7 +193,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, p2shErpRedeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
     }
@@ -209,7 +214,8 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeP2shErpRedeemScript);
-        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
+        Script redeemScriptFromInputScript = extractRedeemScriptFromInputScript(inputScript).get();
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
     }
@@ -239,11 +245,4 @@ public class RedeemScriptParserFactoryTest {
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
     }
-    
-/*    private RedeemScriptParser extractRedeemScriptParserFromInputScript(Script inputScript) {
-        // Last chunk of input script is the redeem script
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        return RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
-    }*/
 }

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -11,6 +11,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static co.rsk.bitcoinj.script.RedeemScriptUtils.extractRedeemScriptParserFromInputScript;
+
 public class RedeemScriptParserFactoryTest {
 
     private List<BtcECKey> defaultRedeemScriptKeys;
@@ -22,14 +24,14 @@ public class RedeemScriptParserFactoryTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_fast_bridge_multiSig_chunk() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             defaultRedeemScriptKeys
         );
@@ -40,7 +42,7 @@ public class RedeemScriptParserFactoryTest {
 
     @Test
     public void create_RedeemScriptParser_object_from_standard_multiSig_chunk() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
@@ -48,7 +50,7 @@ public class RedeemScriptParserFactoryTest {
 
     @Test
     public void create_RedeemScriptParser_object_from_erp_multiSig_chunk() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -61,7 +63,7 @@ public class RedeemScriptParserFactoryTest {
 
     @Test
     public void create_RedeemScriptParser_object_from_erp_fast_bridge_multiSig_chunk() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -75,7 +77,7 @@ public class RedeemScriptParserFactoryTest {
 
     @Test
     public void create_RedeemScriptParser_object_from_p2sh_erp_multiSig_chunk() {
-        Script redeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -88,7 +90,7 @@ public class RedeemScriptParserFactoryTest {
 
     @Test
     public void create_RedeemScriptParser_object_from_fast_bridge_p2sh_erp_multiSig_chunk() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -103,7 +105,7 @@ public class RedeemScriptParserFactoryTest {
     @Test
     public void create_RedeemScriptParser_object_from_fast_bridge_P2SH_chunk() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             defaultRedeemScriptKeys
         );
@@ -114,16 +116,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeRedeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_standard_P2SH_chunk() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
 
         Script spk = ScriptBuilder.createP2SHOutputScript(
             2,
@@ -131,16 +131,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, redeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_erp_P2SH_chunk() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -152,16 +150,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, erpRedeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_fast_bridge_erp_P2SH_chunk() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -174,16 +170,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeErpRedeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_p2sh_erp_P2SH_chunk() {
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script p2shErpRedeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -195,16 +189,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, p2shErpRedeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_fast_bridge_p2sh_erp_P2SH_chunk() {
-        Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script fastBridgeP2shErpRedeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -217,16 +209,14 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeP2shErpRedeemScript);
-        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
-        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+        RedeemScriptParser parser = extractRedeemScriptParserFromInputScript(inputScript).get();
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
     }
 
     @Test
     public void create_RedeemScriptParser_object_from_custom_redeem_script_no_multiSig() {
-        Script redeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createCustomRedeemScript(defaultRedeemScriptKeys);
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
@@ -249,4 +239,11 @@ public class RedeemScriptParserFactoryTest {
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
     }
+    
+/*    private RedeemScriptParser extractRedeemScriptParserFromInputScript(Script inputScript) {
+        // Last chunk of input script is the redeem script
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        return RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
+    }*/
 }

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -4,7 +4,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
-import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +36,6 @@ public class RedeemScriptParserFactoryTest {
 
         RedeemScriptParser parser = RedeemScriptParserFactory.get(fastBridgeRedeemScript.getChunks());
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -46,7 +44,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -60,7 +57,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -75,7 +71,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -89,7 +84,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -104,7 +98,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -121,10 +114,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -137,10 +131,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, redeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -157,10 +152,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, erpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -178,10 +174,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -198,10 +195,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, p2shErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -219,10 +217,11 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeP2shErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
+        ScriptChunk redeemScriptChunksFromInputScript = inputScript.getChunks().get(inputScript.chunks.size() - 1);
+        Script redeemScriptFromInputScript = new Script(redeemScriptChunksFromInputScript.data);
+        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScriptFromInputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -239,7 +238,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());
     }
 
     @Test
@@ -250,6 +248,5 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(erpTestnetRedeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptTestUtils.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptTestUtils.java
@@ -8,7 +8,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
-public class RedeemScriptUtils {
+public class RedeemScriptTestUtils {
 
     protected static Script createStandardRedeemScript(List<BtcECKey> publicKeys) {
         return ScriptBuilder.createRedeemScript(publicKeys.size() / 2 + 1, publicKeys);

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
@@ -20,14 +20,14 @@ public class RedeemScriptValidatorTest {
 
     @Before
     public void setUp() {
-        defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
-        emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+        defaultRedeemScriptKeys = RedeemScriptTestUtils.getDefaultRedeemScriptKeys();
+        emergencyRedeemScriptKeys = RedeemScriptTestUtils.getEmergencyRedeemScriptKeys();
     }
 
     @Test
     public void isRedeemLikeScript_invalid_redeem_script_missing_checkSig() {
         List<ScriptChunk> chunksWithoutCheckSig = RedeemScriptValidator.removeOpCheckMultisig(
-            RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys)
+            RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys)
         );
 
         Assert.assertFalse(RedeemScriptValidator.isRedeemLikeScript(chunksWithoutCheckSig));
@@ -47,13 +47,13 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasStandardRedeemScriptStructure_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         Assert.assertTrue(RedeemScriptValidator.hasStandardRedeemScriptStructure(redeemScript.getChunks()));
     }
 
     @Test
     public void hasStandardRedeemScriptStructure_non_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -64,13 +64,13 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         Assert.assertFalse(RedeemScriptValidator.hasErpRedeemScriptStructure(redeemScript.getChunks()));
     }
 
     @Test
     public void hasErpRedeemScriptStructure_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             Sha256Hash.of(new byte[]{1}).getBytes(),
             defaultRedeemScriptKeys
         );
@@ -80,7 +80,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_one_byte_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             10L
@@ -91,7 +91,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_two_bytes_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -102,7 +102,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_two_bytes_including_sign_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             130L // Any value above 127 needs an extra byte to indicate the sign
@@ -113,7 +113,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_three_bytes_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             100_000L
@@ -124,7 +124,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_three_bytes_including_sign_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             33_000L // Any value above 32_767 needs an extra byte to indicate the sign
@@ -135,7 +135,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_four_bytes_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             10_000_000L
@@ -146,7 +146,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_erp_fed_redeem_script_four_bytes_including_sign_csv_value() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             8_400_000L // Any value above 8_388_607 needs an extra byte to indicate the sign
@@ -157,7 +157,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasErpRedeemScriptStructure_fast_bridge_erp_redeem_script_removing_prefix() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -175,7 +175,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasFastBridgePrefix_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             Sha256Hash.of(new byte[]{1}).getBytes(),
             defaultRedeemScriptKeys
         );
@@ -185,7 +185,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasFastBridgePrefix_erp_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L,
@@ -197,13 +197,13 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void hasFastBridgePrefix_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         Assert.assertFalse(RedeemScriptValidator.hasFastBridgePrefix(redeemScript.getChunks()));
     }
 
     @Test(expected = VerificationException.class)
     public void removeOpCheckMultiSig_non_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
@@ -214,7 +214,7 @@ public class RedeemScriptValidatorTest {
 
     @Test
     public void removeOpCheckMultiSig_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         List<ScriptChunk> chunks = RedeemScriptValidator.removeOpCheckMultisig(redeemScript);
 
         Assert.assertEquals(defaultRedeemScriptKeys.size() + 2, chunks.size()); // 1 chunk per key + OP_M + OP_N

--- a/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
@@ -471,7 +471,7 @@ public class ScriptTest {
     @Test
     public void getNumberOfSignaturesRequiredToSpend_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data, btcECKeyList);
 
         Assert.assertEquals(2, fastBridgeRedeemScript.getNumberOfSignaturesRequiredToSpend());
@@ -479,7 +479,7 @@ public class ScriptTest {
 
     @Test
     public void getNumberOfSignaturesRequiredToSpend_erp_redeem_script() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L
@@ -490,7 +490,7 @@ public class ScriptTest {
 
     @Test
     public void getNumberOfSignaturesRequiredToSpend_fast_bridge_erp_redeem_script() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L,
@@ -502,14 +502,14 @@ public class ScriptTest {
 
     @Test
     public void getNumberOfSignaturesRequiredToSpend_no_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         Assert.assertEquals(2, redeemScript.getNumberOfSignaturesRequiredToSpend());
     }
 
     @Test
     public void getSigInsertionIndex_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data, btcECKeyList);
 
         testGetSigInsertionIndex(fastBridgeRedeemScript);
@@ -517,7 +517,7 @@ public class ScriptTest {
 
     @Test
     public void getSigInsertionIndex_erp_redeem_script() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L
@@ -528,7 +528,7 @@ public class ScriptTest {
 
     @Test
     public void getSigInsertionIndex_fast_bridge_erp_redeem_script() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L,
@@ -540,14 +540,14 @@ public class ScriptTest {
 
     @Test
     public void getSigInsertionIndex_no_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         testGetSigInsertionIndex(redeemScript);
     }
 
     @Test
     public void isSentToMultiSig_fast_bridge_multiSig() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -557,7 +557,7 @@ public class ScriptTest {
 
     @Test
     public void isSentToMultiSig_erp_multiSig() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script erpRedeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L
@@ -568,7 +568,7 @@ public class ScriptTest {
 
     @Test
     public void isSentToMultiSig_fast_bridge_erp_multiSig() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script fastBridgeErpRedeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L,
@@ -580,13 +580,13 @@ public class ScriptTest {
 
     @Test
     public void isStandardMultiSig_standard_multiSig() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         Assert.assertTrue(redeemScript.isSentToMultiSig());
     }
 
     @Test
     public void createEmptyInputScript_standard_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         Script spk = ScriptBuilder.createP2SHOutputScript(redeemScript);
         Script inputScript = spk.createEmptyInputScript(null, redeemScript);
 
@@ -600,7 +600,7 @@ public class ScriptTest {
 
     @Test
     public void createEmptyInputScript_fast_bridge_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             Sha256Hash.of(new byte[]{1}).getBytes(),
             btcECKeyList
         );
@@ -618,7 +618,7 @@ public class ScriptTest {
 
     @Test
     public void createEmptyInputScript_erp_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L
@@ -643,7 +643,7 @@ public class ScriptTest {
 
     @Test
     public void createEmptyInputScript_fast_bridge_erp_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L,
@@ -669,7 +669,7 @@ public class ScriptTest {
 
     @Test
     public void createEmptyInputScript_p2sh_erp_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createP2shErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L
@@ -694,7 +694,7 @@ public class ScriptTest {
 
     @Test
     public void createEmptyInputScript_fast_bridge_p2sh_erp_redeemScript() {
-        Script redeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
+        Script redeemScript = RedeemScriptTestUtils.createFastBridgeP2shErpRedeemScript(
             btcECKeyList,
             erpFedECKeyList,
             500L,

--- a/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
@@ -69,7 +69,7 @@ public class StandardRedeemScriptParserTest {
 
         byte[] txSigEncoded = txSig.encodeToBitcoin();
 
-        int sigIndex = parser.getSigInsertionIndex(sigHash, ecKey1);
+        int sigIndex = inputScript.getSigInsertionIndex(sigHash, ecKey1);
         Assert.assertEquals(0, sigIndex);
 
         inputScript = ScriptBuilder.updateScriptWithSignature(
@@ -82,7 +82,7 @@ public class StandardRedeemScriptParserTest {
 
         parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
-        sigIndex = parser.getSigInsertionIndex(sigHash, ecKey2);
+        sigIndex = inputScript.getSigInsertionIndex(sigHash, ecKey2);
         Assert.assertEquals(1, sigIndex);
     }
 
@@ -123,7 +123,7 @@ public class StandardRedeemScriptParserTest {
         );
         byte[] txSigEncoded = txSig.encodeToBitcoin();
 
-        int sigIndex = parser.getSigInsertionIndex(sigHash, ecKey1);
+        int sigIndex = inputScript.getSigInsertionIndex(sigHash, ecKey1);
         Assert.assertEquals(0, sigIndex);
 
         inputScript = ScriptBuilder.updateScriptWithSignature(
@@ -136,7 +136,7 @@ public class StandardRedeemScriptParserTest {
 
         parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
-        sigIndex = parser.getSigInsertionIndex(sigHash, ecKey2);
+        sigIndex = inputScript.getSigInsertionIndex(sigHash, ecKey2);
         Assert.assertEquals(1, sigIndex);
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
@@ -34,7 +34,7 @@ public class StandardRedeemScriptParserTest {
     @Test
     public void getSigInsertionIndex_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -88,7 +88,7 @@ public class StandardRedeemScriptParserTest {
 
     @Test
     public void getSigInsertionIndex_no_fast_bridge_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
 
         BtcTransaction fundTx = new BtcTransaction(networkParameters);
         fundTx.addOutput(Coin.FIFTY_COINS, ecKey1.toAddress(networkParameters));
@@ -143,7 +143,7 @@ public class StandardRedeemScriptParserTest {
     @Test
     public void findKeyInRedeem_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -158,7 +158,7 @@ public class StandardRedeemScriptParserTest {
     @Test(expected = IllegalStateException.class)
     public void findKeyInRedeem_fast_bridge_redeem_script_no_matching_key() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -171,7 +171,7 @@ public class StandardRedeemScriptParserTest {
 
     @Test(expected = IllegalStateException.class)
     public void findKeyInRedeem_standard_redeem_script_no_matching_key() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         BtcECKey unmatchingBtcECKey = BtcECKey.fromPrivate(BigInteger.valueOf(400));
 
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
@@ -182,7 +182,7 @@ public class StandardRedeemScriptParserTest {
     @Test
     public void getPubKeys_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -208,7 +208,7 @@ public class StandardRedeemScriptParserTest {
 
     @Test
     public void getPubKeys_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
 
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
         List<BtcECKey> obtainedList = parser.getPubKeys();
@@ -248,7 +248,7 @@ public class StandardRedeemScriptParserTest {
     @Test
     public void getM_from_multiSig_fast_bridge_redeem_script() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+        Script fastBridgeRedeemScript = RedeemScriptTestUtils.createFastBridgeRedeemScript(
             data,
             btcECKeyList
         );
@@ -260,7 +260,7 @@ public class StandardRedeemScriptParserTest {
 
     @Test
     public void getM_from_multiSig_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
+        Script redeemScript = RedeemScriptTestUtils.createStandardRedeemScript(btcECKeyList);
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(2, parser.getM());


### PR DESCRIPTION
Remove RedeemScriptParser from Script constructor. Make RedeemScriptParserFactory only parse redeem scripts (not scripsigs anymore). Return getSigInsertionIndex method to Script class. Remove ParseResult class.