### PR TITLE
Second part - Change method signature on extractStandardRedeemScript

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -21,13 +21,13 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks),
+            extractStandardRedeemScriptChunks(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.ERP_FED;
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
         List<ScriptChunk> chunksForRedeem = new ArrayList<>();
 
         int i = 1;

--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -21,13 +21,13 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
+            extractStandardRedeemScript(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.ERP_FED;
     }
 
-    public static Script extractStandardRedeemScript(List<ScriptChunk> chunks) {
+    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
         List<ScriptChunk> chunksForRedeem = new ArrayList<>();
 
         int i = 1;
@@ -45,7 +45,7 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
             throw new VerificationException(message);
         }
 
-        return new Script(chunksForRedeem);
+        return chunksForRedeem;
     }
 
     public static Script createErpRedeemScript(

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -16,15 +16,14 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks).getChunks(),
+            extractStandardRedeemScript(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_ERP_FED;
     }
 
-    public static Script extractStandardRedeemScript(List<ScriptChunk> chunks) {
-        return ErpFederationRedeemScriptParser.
-            extractStandardRedeemScript(chunks.subList(2, chunks.size()));
+    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
+        return ErpFederationRedeemScriptParser.extractStandardRedeemScript(chunks.subList(2, chunks.size()));
     }
 
     public static Script createFastBridgeErpRedeemScript(

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -16,14 +16,14 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks),
+            extractStandardRedeemScriptChunks(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_ERP_FED;
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
-        return ErpFederationRedeemScriptParser.extractStandardRedeemScript(chunks.subList(2, chunks.size()));
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
+        return ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(chunks.subList(2, chunks.size()));
     }
 
     public static Script createFastBridgeErpRedeemScript(

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
@@ -17,15 +17,15 @@ public class FastBridgeP2shErpRedeemScriptParser extends StandardRedeemScriptPar
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks),
+            extractStandardRedeemScriptChunks(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_P2SH_ERP_FED;
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
         return P2shErpFederationRedeemScriptParser.
-            extractStandardRedeemScript(chunks.subList(2, chunks.size()));
+            extractStandardRedeemScriptChunks(chunks.subList(2, chunks.size()));
     }
 
     public static Script createFastBridgeP2shErpRedeemScript(

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
@@ -29,7 +29,7 @@ public class FastBridgeRedeemScriptParser extends StandardRedeemScriptParser {
         return derivationHash;
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScript(Script redeemScript) {
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(Script redeemScript) {
         return ScriptBuilder.createRedeemScript(
             redeemScript.getNumberOfSignaturesRequiredToSpend(),
             redeemScript.getPubKeys()

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
@@ -29,11 +29,11 @@ public class FastBridgeRedeemScriptParser extends StandardRedeemScriptParser {
         return derivationHash;
     }
 
-    public static Script extractStandardRedeemScript(Script redeemScript) {
+    public static List<ScriptChunk> extractStandardRedeemScript(Script redeemScript) {
         return ScriptBuilder.createRedeemScript(
             redeemScript.getNumberOfSignaturesRequiredToSpend(),
             redeemScript.getPubKeys()
-        );
+        ).getChunks();
     }
 
     public static Script createMultiSigFastBridgeRedeemScript(

--- a/src/main/java/co/rsk/bitcoinj/script/NoRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NoRedeemScriptParser.java
@@ -43,7 +43,7 @@ public class NoRedeemScriptParser implements RedeemScriptParser {
     }
 
     @Override
-    public List<ScriptChunk> extractStandardRedeemScript() {
+    public List<ScriptChunk> extractStandardRedeemScriptChunks() {
         throw new ScriptException("Only usable for multisig scripts.");
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
@@ -20,13 +20,13 @@ public class P2shErpFederationRedeemScriptParser extends StandardRedeemScriptPar
     ) {
         super(
             scriptType,
-            extractStandardRedeemScript(redeemScriptChunks),
+            extractStandardRedeemScriptChunks(redeemScriptChunks),
             rawChunks
         );
         this.multiSigType = MultiSigType.P2SH_ERP_FED;
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScript(List<ScriptChunk> chunks) {
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
         List<ScriptChunk> chunksForRedeem = new ArrayList<>();
 
         int i = 1;

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
@@ -36,5 +36,5 @@ public interface RedeemScriptParser {
 
     int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash);
 
-    List<ScriptChunk> extractStandardRedeemScript();
+    List<ScriptChunk> extractStandardRedeemScriptChunks();
 }

--- a/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
@@ -119,7 +119,7 @@ public class StandardRedeemScriptParser implements RedeemScriptParser {
     }
 
     @Override
-    public List<ScriptChunk> extractStandardRedeemScript() {
+    public List<ScriptChunk> extractStandardRedeemScriptChunks() {
         return redeemScriptChunks;
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -21,7 +21,7 @@ public class ErpFederationRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScript_fromErpRedeemScript() {
+    public void extractStandardRedeemScriptChunks_fromErpRedeemScript() {
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -30,17 +30,17 @@ public class ErpFederationRedeemScriptParserTest {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        List<ScriptChunk> obtainedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScript(erpRedeemScript.getChunks());
+        List<ScriptChunk> obtainedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(erpRedeemScript.getChunks());
 
         Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)
-    public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
+    public void extractStandardRedeemScriptChunks_fromStandardRedeemScript_fail() {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
-        ErpFederationRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
+        ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(standardRedeemScript.getChunks());
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParserTest.java
@@ -27,14 +27,12 @@ public class ErpFederationRedeemScriptParserTest {
             emergencyRedeemScriptKeys,
             100L
         );
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
-            defaultRedeemScriptKeys);
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        Script obtainedRedeemScript = ErpFederationRedeemScriptParser.extractStandardRedeemScript(
-            erpRedeemScript.getChunks()
-        );
+        List<ScriptChunk> obtainedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScript(erpRedeemScript.getChunks());
 
-        Assert.assertEquals(standardRedeemScript, obtainedRedeemScript);
+        Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
@@ -30,14 +30,12 @@ public class FastBridgeErpRedeemScriptParserTest {
             derivationArgumentsHash.getBytes()
         );
 
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
-            defaultRedeemScriptKeys);
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        Script obtainedRedeemScript = FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(
-            fastBridgeErpRedeemScript.getChunks()
-        );
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(fastBridgeErpRedeemScript.getChunks());
 
-        Assert.assertEquals(standardRedeemScript, obtainedRedeemScript);
+        Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParserTest.java
@@ -20,7 +20,7 @@ public class FastBridgeErpRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScript_fromFastBridgeErpRedeemScript() {
+    public void extractStandardRedeemScriptChunks_fromFastBridgeErpRedeemScript() {
         Long csvValue = 100L;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
@@ -33,17 +33,17 @@ public class FastBridgeErpRedeemScriptParserTest {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(fastBridgeErpRedeemScript.getChunks());
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeErpRedeemScriptParser.extractStandardRedeemScriptChunks(fastBridgeErpRedeemScript.getChunks());
 
         Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)
-    public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
+    public void extractStandardRedeemScriptChunks_fromStandardRedeemScript_fail() {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys);
 
-        FastBridgeErpRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
+        FastBridgeErpRedeemScriptParser.extractStandardRedeemScriptChunks(standardRedeemScript.getChunks());
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParserTest.java
@@ -29,7 +29,7 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScript_fromFastBridgeP2shErpRedeemScript() {
+    public void extractStandardRedeemScriptChunks_fromFastBridgeP2ShErpRedeemScript() {
         Long csvValue = 100L;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
@@ -41,18 +41,18 @@ public class FastBridgeP2shErpRedeemScriptParserTest {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeP2shErpRedeemScriptParser.extractStandardRedeemScript(fastBridgeP2shErpRedeemScript.getChunks());
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeP2shErpRedeemScriptParser.extractStandardRedeemScriptChunks(fastBridgeP2shErpRedeemScript.getChunks());
 
         Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)
-    public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
+    public void extractStandardRedeemScriptChunks_fromStandardRedeemScript_fail() {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
-        FastBridgeP2shErpRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
+        FastBridgeP2shErpRedeemScriptParser.extractStandardRedeemScriptChunks(standardRedeemScript.getChunks());
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
@@ -18,7 +18,7 @@ public class FastBridgeRedeemScriptParserTest {
     }
 
     @Test
-    public void extractRedeemScriptFromMultiSigFastBridgeRedeemScript_fb_redeem_script() {
+    public void extractStandardRedeemScriptChunks_whenGetFromMultiSigFastBridgeRedeemScript_shouldReturnScripChunks() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
         Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
             data,
@@ -28,16 +28,16 @@ public class FastBridgeRedeemScriptParserTest {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
         List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScript(fastBridgeRedeemScript);
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScriptChunks(fastBridgeRedeemScript);
 
         Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test
-    public void extractRedeemScriptFromMultiSigFastBridgeRedeemScript_std_redeem_script() {
+    public void extractStandardRedeemScriptChunks_whenGetFromMultiSigStandardRedeemScript_shouldReturnScripChunks() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
         List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
-        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScript(redeemScript);
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScriptChunks(redeemScript);
 
         Assert.assertEquals(redeemScriptChunks, obtainedRedeemScriptChunks);
     }

--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
@@ -26,20 +26,20 @@ public class FastBridgeRedeemScriptParserTest {
         );
 
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
+        List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        Script obtainedRedeemScript = FastBridgeRedeemScriptParser.extractStandardRedeemScript(
-            fastBridgeRedeemScript
-        );
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScript(fastBridgeRedeemScript);
 
-        Assert.assertEquals(standardRedeemScript, obtainedRedeemScript);
+        Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test
     public void extractRedeemScriptFromMultiSigFastBridgeRedeemScript_std_redeem_script() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(publicKeys);
-        Script obtainedRedeemScript = FastBridgeRedeemScriptParser.extractStandardRedeemScript(redeemScript);
+        List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
+        List<ScriptChunk> obtainedRedeemScriptChunks = FastBridgeRedeemScriptParser.extractStandardRedeemScript(redeemScript);
 
-        Assert.assertEquals(redeemScript, obtainedRedeemScript);
+        Assert.assertEquals(redeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/NoRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/NoRedeemScriptParserTest.java
@@ -8,8 +8,8 @@ public class NoRedeemScriptParserTest {
     private final RedeemScriptParser noRedeemScriptParser = new NoRedeemScriptParser();
 
     @Test (expected = ScriptException.class)
-    public void extractStandardRedeemScript_shouldThrowScriptException() {
+    public void extractStandardRedeemScriptChunks_shouldThrowScriptException() {
         // Act
-        noRedeemScriptParser.extractStandardRedeemScript();
+        noRedeemScriptParser.extractStandardRedeemScriptChunks();
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParserTest.java
@@ -20,7 +20,7 @@ public class P2shErpFederationRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScript_fromP2shErpRedeemScript() {
+    public void extractStandardRedeemScriptChunks_fromP2ShErpRedeemScript() {
         Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -29,18 +29,18 @@ public class P2shErpFederationRedeemScriptParserTest {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
 
-        List<ScriptChunk> obtainedRedeemScriptChunks = P2shErpFederationRedeemScriptParser.extractStandardRedeemScript(erpRedeemScript.getChunks());
+        List<ScriptChunk> obtainedRedeemScriptChunks = P2shErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(erpRedeemScript.getChunks());
 
         Assert.assertEquals(standardRedeemScriptChunks, obtainedRedeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)
-    public void extractStandardRedeemScript_fromStandardRedeemScript_fail() {
+    public void extractStandardRedeemScriptChunks_fromStandardRedeemScript_fail() {
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(
             defaultRedeemScriptKeys
         );
 
-        P2shErpFederationRedeemScriptParser.extractStandardRedeemScript(standardRedeemScript.getChunks());
+        P2shErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(standardRedeemScript.getChunks());
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
@@ -269,14 +269,14 @@ public class StandardRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScript_whenGetScriptChunksFromStandardRedeemScriptParser_shouldReturnScriptChunks() {
+    public void extractStandardRedeemScriptChunks_whenGetScriptChunksFromStandardRedeemScriptParser_shouldReturnScriptChunks() {
         // Arrange
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(btcECKeyList);
         List<ScriptChunk> expectedRedeemScriptChunks = redeemScript.getChunks();
         RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         // Act
-        List<ScriptChunk> actualRedeemScripChunks = redeemScriptParser.extractStandardRedeemScript();
+        List<ScriptChunk> actualRedeemScripChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
 
         // Assert
         assertEquals(expectedRedeemScriptChunks, actualRedeemScripChunks);


### PR DESCRIPTION
## Description

Change method signature on RedeemScriptParser#extractStandardRedeemScript.

Old method signature: Script extractStandardRedeemScript();

New method signature: List<ScriptChunk> extractStandardRedeemScript();

Object Impacted:

ErpFederationRedeemScriptParser
FastBridgeErpRedeemScriptParser
FastBridgeRedeemScriptParser

## Motivation and Context
This relates to the Reactors to add `SegwitRedeemScriptParser`.


## How Has This Been Tested?
Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
