### PR TITLE
Get rid of raw chunks from standard redeem script parser

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -16,13 +16,11 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
 
     public ErpFederationRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
             scriptType,
-            extractStandardRedeemScriptChunks(redeemScriptChunks),
-            rawChunks
+            extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -11,13 +11,11 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
 
     public FastBridgeErpRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
             scriptType,
-            extractStandardRedeemScriptChunks(redeemScriptChunks),
-            rawChunks
+            extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
@@ -12,13 +12,11 @@ public class FastBridgeP2shErpRedeemScriptParser extends StandardRedeemScriptPar
 
     public FastBridgeP2shErpRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
             scriptType,
-            extractStandardRedeemScriptChunks(redeemScriptChunks),
-            rawChunks
+            extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_P2SH_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
@@ -13,13 +13,11 @@ public class FastBridgeRedeemScriptParser extends StandardRedeemScriptParser {
 
     public FastBridgeRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
             scriptType,
-            redeemScriptChunks.subList(2, redeemScriptChunks.size()),
-            rawChunks
+            redeemScriptChunks.subList(2, redeemScriptChunks.size())
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_MULTISIG;
         this.derivationHash = redeemScriptChunks.get(0).data;

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
@@ -15,13 +15,11 @@ public class P2shErpFederationRedeemScriptParser extends StandardRedeemScriptPar
 
     public P2shErpFederationRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         super(
             scriptType,
-            extractStandardRedeemScriptChunks(redeemScriptChunks),
-            rawChunks
+            extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.P2SH_ERP_FED;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -37,48 +37,42 @@ public class RedeemScriptParserFactory {
             logger.debug("[get] Return FastBridgeRedeemScriptParser");
             return new FastBridgeRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
         if (StandardRedeemScriptParser.isStandardMultiSig(result.internalScript)) {
             logger.debug("[get] Return StandardRedeemScriptParser");
             return new StandardRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
         if (P2shErpFederationRedeemScriptParser.isP2shErpFed(result.internalScript)) {
             logger.debug("[get] Return P2shErpFederationRedeemScriptParser");
             return new P2shErpFederationRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
         if (FastBridgeP2shErpRedeemScriptParser.isFastBridgeP2shErpFed(result.internalScript)) {
             logger.debug("[get] Return FastBridgeP2shErpRedeemScriptParser");
             return new FastBridgeP2shErpRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
         if (ErpFederationRedeemScriptParser.isErpFed(result.internalScript)) {
             logger.debug("[get] Return ErpFederationRedeemScriptParser");
             return new ErpFederationRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
         if (FastBridgeErpRedeemScriptParser.isFastBridgeErpFed(result.internalScript)) {
             logger.debug("[get] Return FastBridgeErpRedeemScriptParser");
             return new FastBridgeErpRedeemScriptParser(
                 result.scriptType,
-                result.internalScript,
-                chunks
+                result.internalScript
             );
         }
 

--- a/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
@@ -17,20 +17,16 @@ public class StandardRedeemScriptParser implements RedeemScriptParser {
     protected MultiSigType multiSigType;
     protected ScriptType scriptType;
     // In case of P2SH represents a scriptSig, where the last chunk is the redeem script (either standard or extended)
-    protected List<ScriptChunk> rawChunks;
     // Standard redeem script
     protected List<ScriptChunk> redeemScriptChunks;
 
     public StandardRedeemScriptParser(
         ScriptType scriptType,
-        List<ScriptChunk> redeemScriptChunks,
-        List<ScriptChunk> rawChunks
+        List<ScriptChunk> redeemScriptChunks
     ) {
         this.multiSigType = MultiSigType.STANDARD_MULTISIG;
         this.scriptType = scriptType;
         this.redeemScriptChunks = redeemScriptChunks;
-
-        this.rawChunks = Collections.unmodifiableList(new ArrayList<>(rawChunks));
     }
 
     @Override


### PR DESCRIPTION
## Motivation and Context

Since the sigInsertionIndex method is not part of the RedeemScriptParsers, the rawChunks become useless to the class. Therefore, we propose to get rid of it from StandardRedeemScriptParser.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
