### PR TITLE
Get rid of script type from RedeemScriptParser interface

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ErpFederationRedeemScriptParser.java
@@ -15,11 +15,9 @@ public class ErpFederationRedeemScriptParser extends StandardRedeemScriptParser 
     public static long MAX_CSV_VALUE = 65_535L; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value
 
     public ErpFederationRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
             extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.ERP_FED;

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeErpRedeemScriptParser.java
@@ -10,11 +10,9 @@ public class FastBridgeErpRedeemScriptParser extends StandardRedeemScriptParser 
     private static final Logger logger = LoggerFactory.getLogger(FastBridgeErpRedeemScriptParser.class);
 
     public FastBridgeErpRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
             extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_ERP_FED;

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeP2shErpRedeemScriptParser.java
@@ -11,11 +11,9 @@ public class FastBridgeP2shErpRedeemScriptParser extends StandardRedeemScriptPar
     private static final Logger logger = LoggerFactory.getLogger(FastBridgeP2shErpRedeemScriptParser.class);
 
     public FastBridgeP2shErpRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
             extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_P2SH_ERP_FED;

--- a/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParser.java
@@ -12,11 +12,9 @@ public class FastBridgeRedeemScriptParser extends StandardRedeemScriptParser {
     protected final byte[] derivationHash;
 
     public FastBridgeRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
             redeemScriptChunks.subList(2, redeemScriptChunks.size())
         );
         this.multiSigType = MultiSigType.FAST_BRIDGE_MULTISIG;

--- a/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcoded.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcoded.java
@@ -13,11 +13,6 @@ public class NonStandardErpRedeemScriptParserHardcoded implements RedeemScriptPa
     }
 
     @Override
-    public ScriptType getScriptType() {
-        return ScriptType.UNDEFINED;
-    }
-
-    @Override
     public int getM() {
         return -1;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpFederationRedeemScriptParser.java
@@ -14,11 +14,9 @@ public class P2shErpFederationRedeemScriptParser extends StandardRedeemScriptPar
     public static long MAX_CSV_VALUE = 65_535L; // 2^16 - 1, since bitcoin will interpret up to 16 bits as the CSV value
 
     public P2shErpFederationRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         super(
-            scriptType,
             extractStandardRedeemScriptChunks(redeemScriptChunks)
         );
         this.multiSigType = MultiSigType.P2SH_ERP_FED;

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
@@ -16,15 +16,7 @@ public interface RedeemScriptParser {
         FAST_BRIDGE_P2SH_ERP_FED
     }
 
-    enum ScriptType {
-        P2SH,
-        REDEEM_SCRIPT,
-        UNDEFINED
-    }
-
     MultiSigType getMultiSigType();
-
-    ScriptType getScriptType();
 
     int getM();
 

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -2,7 +2,6 @@ package co.rsk.bitcoinj.script;
 
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Utils;
-import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,42 +35,36 @@ public class RedeemScriptParserFactory {
         if (FastBridgeRedeemScriptParser.isFastBridgeMultiSig(result.internalScript)) {
             logger.debug("[get] Return FastBridgeRedeemScriptParser");
             return new FastBridgeRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
         if (StandardRedeemScriptParser.isStandardMultiSig(result.internalScript)) {
             logger.debug("[get] Return StandardRedeemScriptParser");
             return new StandardRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
         if (P2shErpFederationRedeemScriptParser.isP2shErpFed(result.internalScript)) {
             logger.debug("[get] Return P2shErpFederationRedeemScriptParser");
             return new P2shErpFederationRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
         if (FastBridgeP2shErpRedeemScriptParser.isFastBridgeP2shErpFed(result.internalScript)) {
             logger.debug("[get] Return FastBridgeP2shErpRedeemScriptParser");
             return new FastBridgeP2shErpRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
         if (ErpFederationRedeemScriptParser.isErpFed(result.internalScript)) {
             logger.debug("[get] Return ErpFederationRedeemScriptParser");
             return new ErpFederationRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
         if (FastBridgeErpRedeemScriptParser.isFastBridgeErpFed(result.internalScript)) {
             logger.debug("[get] Return FastBridgeErpRedeemScriptParser");
             return new FastBridgeErpRedeemScriptParser(
-                result.scriptType,
                 result.internalScript
             );
         }
@@ -83,7 +76,7 @@ public class RedeemScriptParserFactory {
     private static ParseResult extractRedeemScriptFromChunks(List<ScriptChunk> chunks) {
         ScriptChunk lastChunk = chunks.get(chunks.size() - 1);
         if (RedeemScriptValidator.isRedeemLikeScript(chunks)) {
-            return new ParseResult(chunks, ScriptType.REDEEM_SCRIPT);
+            return new ParseResult(chunks);
         }
         if (lastChunk.data != null && lastChunk.data.length > 0) {
             int lastByte = lastChunk.data[lastChunk.data.length - 1] & 0xff;
@@ -99,7 +92,7 @@ public class RedeemScriptParserFactory {
                     logger.debug("[extractRedeemScriptFromChunks] {}", message);
                     throw new ScriptException(message);
                 }
-                return new ParseResult(result.getChunks(), ScriptType.P2SH);
+                return new ParseResult(result.getChunks());
             }
         }
         logger.debug("[extractRedeemScriptFromChunks] Could not get redeem script from given chunks");
@@ -108,11 +101,9 @@ public class RedeemScriptParserFactory {
 
     private static class ParseResult {
         public final List<ScriptChunk> internalScript;
-        public final ScriptType scriptType;
 
-        public ParseResult(List<ScriptChunk> internalScript, ScriptType scriptType) {
+        public ParseResult(List<ScriptChunk> internalScript) {
             this.internalScript = internalScript;
-            this.scriptType = scriptType;
         }
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
@@ -9,34 +9,25 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class StandardRedeemScriptParser implements RedeemScriptParser {
 
     protected MultiSigType multiSigType;
-    protected ScriptType scriptType;
     // In case of P2SH represents a scriptSig, where the last chunk is the redeem script (either standard or extended)
     // Standard redeem script
     protected List<ScriptChunk> redeemScriptChunks;
 
     public StandardRedeemScriptParser(
-        ScriptType scriptType,
         List<ScriptChunk> redeemScriptChunks
     ) {
         this.multiSigType = MultiSigType.STANDARD_MULTISIG;
-        this.scriptType = scriptType;
         this.redeemScriptChunks = redeemScriptChunks;
     }
 
     @Override
     public MultiSigType getMultiSigType() {
         return this.multiSigType;
-    }
-
-    @Override
-    public ScriptType getScriptType() {
-        return this.scriptType;
     }
 
     @Override

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -4,7 +4,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
-import co.rsk.bitcoinj.script.RedeemScriptParser.ScriptType;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +36,6 @@ public class RedeemScriptParserFactoryTest {
 
         RedeemScriptParser parser = RedeemScriptParserFactory.get(fastBridgeRedeemScript.getChunks());
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -46,7 +44,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -60,7 +57,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -75,7 +71,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -89,7 +84,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -104,7 +98,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.REDEEM_SCRIPT, parser.getScriptType());
     }
 
     @Test
@@ -124,7 +117,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -140,7 +132,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.STANDARD_MULTISIG, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -160,7 +151,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -181,7 +171,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -201,7 +190,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -222,7 +210,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
 
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.P2SH, parser.getScriptType());
     }
 
     @Test
@@ -239,7 +226,6 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());
     }
 
     @Test
@@ -250,6 +236,5 @@ public class RedeemScriptParserFactoryTest {
         RedeemScriptParser parser = RedeemScriptParserFactory.get(erpTestnetRedeemScript.getChunks());
 
         Assert.assertEquals(MultiSigType.NO_MULTISIG_TYPE, parser.getMultiSigType());
-        Assert.assertEquals(ScriptType.UNDEFINED, parser.getScriptType());
     }
 }


### PR DESCRIPTION
- Remove getScriptType from the RedeemScriptParser interface.
- Also, remove ScriptType enum.
- Update tests according to the new changes.

## Motivation and Context

We have already moved non-redeem script-related methods out of the RedeemScriptParser interface since RedeemScriptParsers should only parse scripts of RedeemScript type. This means the getScriptType method is not needed anymore and can be removed from the RedeemScriptParser.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
