### PR TITLE
Create FlyoverRedeemScriptParser Class

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -1,0 +1,114 @@
+package co.rsk.bitcoinj.script;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.Utils;
+import co.rsk.bitcoinj.core.VerificationException;
+import co.rsk.bitcoinj.crypto.TransactionSignature;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FlyoverRedeemScriptParser implements RedeemScriptParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(FlyoverRedeemScriptParser.class);
+
+    private final MultiSigType multiSigType;
+    private final List<ScriptChunk> redeemScriptChunks;
+    private final RedeemScriptParser redeemScriptParser;
+
+    public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
+        this.redeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
+        this.redeemScriptParser = RedeemScriptParserFactory.get(redeemScriptChunks);
+        this.multiSigType = MultiSigType.FLYOVER;
+    }
+
+    @Override
+    public ScriptType getScriptType() {
+        return null;
+    }
+
+    @Override
+    public int getSigInsertionIndex(Sha256Hash hash, BtcECKey signingKey) {
+        return 0;
+    }
+
+    @Override
+    public MultiSigType getMultiSigType() {
+        return multiSigType;
+    }
+
+    @Override
+    public int getM() {
+        checkArgument(redeemScriptChunks.get(0).isOpCode());
+        return Script.decodeFromOpN(redeemScriptChunks.get(0).opcode);
+    }
+
+    @Override
+    public int findKeyInRedeem(BtcECKey key) {
+        checkArgument(redeemScriptChunks.get(0).isOpCode()); // P2SH scriptSig
+        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
+        for (int i = 0; i < numKeys; i++) {
+            if (Arrays.equals(redeemScriptChunks.get(1 + i).data, key.getPubKey())) {
+                return i;
+            }
+        }
+
+        throw new IllegalStateException("Could not find matching key " + key.toString() + " in script " + this);
+    }
+
+    @Override
+    public List<BtcECKey> getPubKeys() {
+        ArrayList<BtcECKey> result = Lists.newArrayList();
+        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
+        for (int i = 0; i < numKeys; i++) {
+            result.add(BtcECKey.fromPublicOnly(redeemScriptChunks.get(1 + i).data));
+        }
+
+        return result;
+    }
+
+    @Override
+    public int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash) {
+        checkArgument(redeemScriptChunks.get(0).isOpCode()); // P2SH scriptSig
+        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
+        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true);
+        for (int i = 0; i < numKeys; i++) {
+            if (BtcECKey.fromPublicOnly(redeemScriptChunks.get(i + 1).data).verify(hash, signature)) {
+                return i;
+            }
+        }
+        throw new IllegalStateException("Could not find matching key for signature on " + hash.toString()
+            + " sig " + Utils.HEX.encode(signatureBytes)
+        );
+    }
+
+    @Override
+    public List<ScriptChunk> extractStandardRedeemScriptChunks() {
+        return redeemScriptParser.extractStandardRedeemScriptChunks();
+    }
+
+    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
+        List<ScriptChunk> chunksForRedeem = new ArrayList<>();
+
+        int i = 1;
+        while (i < chunks.size() && !chunks.get(i).equalsOpCode(ScriptOpCodes.OP_ELSE)) {
+            chunksForRedeem.add(chunks.get(i));
+            i++;
+        }
+
+        // Validate the obtained redeem script has a valid format
+        if (!RedeemScriptValidator.hasStandardRedeemScriptStructure(chunksForRedeem)) {
+            String message = "Flyover redeem script obtained has an invalid structure";
+            logger.debug("[extractStandardRedeemScriptChunks] {} {}", message, chunksForRedeem);
+            throw new VerificationException(message);
+        }
+
+        return chunksForRedeem;
+    }
+}

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -11,13 +11,11 @@ import org.slf4j.LoggerFactory;
 public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     private static final Logger logger = LoggerFactory.getLogger(FlyoverRedeemScriptParser.class);
-    private final MultiSigType multiSigType;
     private final RedeemScriptParser redeemScriptParser;
 
     public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
         List<ScriptChunk> standardRedeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
         this.redeemScriptParser = RedeemScriptParserFactory.get(standardRedeemScriptChunks);
-        this.multiSigType = MultiSigType.FLYOVER;
     }
 
     @Override
@@ -32,7 +30,7 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     @Override
     public MultiSigType getMultiSigType() {
-        return multiSigType;
+        return MultiSigType.FLYOVER;
     }
 
     @Override

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -1,15 +1,9 @@
 package co.rsk.bitcoinj.script;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.core.VerificationException;
-import co.rsk.bitcoinj.crypto.TransactionSignature;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,14 +11,12 @@ import org.slf4j.LoggerFactory;
 public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     private static final Logger logger = LoggerFactory.getLogger(FlyoverRedeemScriptParser.class);
-
     private final MultiSigType multiSigType;
-    private final List<ScriptChunk> redeemScriptChunks;
     private final RedeemScriptParser redeemScriptParser;
 
     public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
-        this.redeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
-        this.redeemScriptParser = RedeemScriptParserFactory.get(this.redeemScriptChunks.subList(2, this.redeemScriptChunks.size()));
+        List<ScriptChunk> standardRedeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
+        this.redeemScriptParser = RedeemScriptParserFactory.get(standardRedeemScriptChunks);
         this.multiSigType = MultiSigType.FLYOVER;
     }
 
@@ -45,47 +37,22 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     @Override
     public int getM() {
-        checkArgument(redeemScriptChunks.get(0).isOpCode());
-        return Script.decodeFromOpN(redeemScriptChunks.get(0).opcode);
+        return redeemScriptParser.getM();
     }
 
     @Override
     public int findKeyInRedeem(BtcECKey key) {
-        checkArgument(redeemScriptChunks.get(0).isOpCode()); // P2SH scriptSig
-        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
-        for (int i = 0; i < numKeys; i++) {
-            if (Arrays.equals(redeemScriptChunks.get(1 + i).data, key.getPubKey())) {
-                return i;
-            }
-        }
-
-        throw new IllegalStateException("Could not find matching key " + key.toString() + " in script " + this);
+        return redeemScriptParser.findKeyInRedeem(key);
     }
 
     @Override
     public List<BtcECKey> getPubKeys() {
-        ArrayList<BtcECKey> result = Lists.newArrayList();
-        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
-        for (int i = 0; i < numKeys; i++) {
-            result.add(BtcECKey.fromPublicOnly(redeemScriptChunks.get(1 + i).data));
-        }
-
-        return result;
+        return redeemScriptParser.getPubKeys();
     }
 
     @Override
     public int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash) {
-        checkArgument(redeemScriptChunks.get(0).isOpCode()); // P2SH scriptSig
-        int numKeys = Script.decodeFromOpN(redeemScriptChunks.get(redeemScriptChunks.size() - 2).opcode);
-        TransactionSignature signature = TransactionSignature.decodeFromBitcoin(signatureBytes, true);
-        for (int i = 0; i < numKeys; i++) {
-            if (BtcECKey.fromPublicOnly(redeemScriptChunks.get(i + 1).data).verify(hash, signature)) {
-                return i;
-            }
-        }
-        throw new IllegalStateException("Could not find matching key for signature on " + hash.toString()
-            + " sig " + Utils.HEX.encode(signatureBytes)
-        );
+        return redeemScriptParser.findSigInRedeem(signatureBytes, hash);
     }
 
     @Override

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -19,16 +19,6 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
     }
 
     @Override
-    public ScriptType getScriptType() {
-        return null;
-    }
-
-    @Override
-    public int getSigInsertionIndex(Sha256Hash hash, BtcECKey signingKey) {
-        return 0;
-    }
-
-    @Override
     public MultiSigType getMultiSigType() {
         return MultiSigType.FLYOVER;
     }

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -10,11 +10,11 @@ import org.slf4j.LoggerFactory;
 public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     private static final Logger logger = LoggerFactory.getLogger(FlyoverRedeemScriptParser.class);
-    private final RedeemScriptParser redeemScriptParser;
+    private final RedeemScriptParser internalRedeemScriptParser;
 
     public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
         List<ScriptChunk> internalRedeemScriptChunks = extractInternalRedeemScriptChunks(redeemScriptChunks);
-        this.redeemScriptParser = RedeemScriptParserFactory.get(internalRedeemScriptChunks);
+        this.internalRedeemScriptParser = RedeemScriptParserFactory.get(internalRedeemScriptChunks);
     }
 
     @Override
@@ -24,27 +24,27 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     @Override
     public int getM() {
-        return redeemScriptParser.getM();
+        return internalRedeemScriptParser.getM();
     }
 
     @Override
     public int findKeyInRedeem(BtcECKey key) {
-        return redeemScriptParser.findKeyInRedeem(key);
+        return internalRedeemScriptParser.findKeyInRedeem(key);
     }
 
     @Override
     public List<BtcECKey> getPubKeys() {
-        return redeemScriptParser.getPubKeys();
+        return internalRedeemScriptParser.getPubKeys();
     }
 
     @Override
     public int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash) {
-        return redeemScriptParser.findSigInRedeem(signatureBytes, hash);
+        return internalRedeemScriptParser.findSigInRedeem(signatureBytes, hash);
     }
 
     @Override
     public List<ScriptChunk> extractStandardRedeemScriptChunks() {
-        return redeemScriptParser.extractStandardRedeemScriptChunks();
+        return internalRedeemScriptParser.extractStandardRedeemScriptChunks();
     }
 
     public static List<ScriptChunk> extractInternalRedeemScriptChunks(List<ScriptChunk> chunks) {

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -47,7 +47,7 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
         return internalRedeemScriptParser.extractStandardRedeemScriptChunks();
     }
 
-    public static List<ScriptChunk> extractInternalRedeemScriptChunks(List<ScriptChunk> chunks) {
+    private static List<ScriptChunk> extractInternalRedeemScriptChunks(List<ScriptChunk> chunks) {
         if (chunks.size() <= 2) {
             String message = "Flyover redeem script obtained has an invalid structure";
             logger.debug("[extractInternalRedeemScriptChunks] {}", message);

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -24,7 +24,7 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
 
     public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
         this.redeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
-        this.redeemScriptParser = RedeemScriptParserFactory.get(redeemScriptChunks);
+        this.redeemScriptParser = RedeemScriptParserFactory.get(this.redeemScriptChunks.subList(2, this.redeemScriptChunks.size()));
         this.multiSigType = MultiSigType.FLYOVER;
     }
 

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -3,7 +3,6 @@ package co.rsk.bitcoinj.script;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.VerificationException;
-import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,8 +13,8 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
     private final RedeemScriptParser redeemScriptParser;
 
     public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
-        List<ScriptChunk> standardRedeemScriptChunks = extractStandardRedeemScriptChunks(redeemScriptChunks);
-        this.redeemScriptParser = RedeemScriptParserFactory.get(standardRedeemScriptChunks);
+        List<ScriptChunk> internalRedeemScriptChunks = extractInternalRedeemScriptChunks(redeemScriptChunks);
+        this.redeemScriptParser = RedeemScriptParserFactory.get(internalRedeemScriptChunks);
     }
 
     @Override
@@ -48,22 +47,13 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
         return redeemScriptParser.extractStandardRedeemScriptChunks();
     }
 
-    public static List<ScriptChunk> extractStandardRedeemScriptChunks(List<ScriptChunk> chunks) {
-        List<ScriptChunk> chunksForRedeem = new ArrayList<>();
-
-        int i = 1;
-        while (i < chunks.size() && !chunks.get(i).equalsOpCode(ScriptOpCodes.OP_ELSE)) {
-            chunksForRedeem.add(chunks.get(i));
-            i++;
-        }
-
-        // Validate the obtained redeem script has a valid format
-        if (!RedeemScriptValidator.hasStandardRedeemScriptStructure(chunksForRedeem)) {
+    public static List<ScriptChunk> extractInternalRedeemScriptChunks(List<ScriptChunk> chunks) {
+        if (chunks.size() <= 2) {
             String message = "Flyover redeem script obtained has an invalid structure";
-            logger.debug("[extractStandardRedeemScriptChunks] {} {}", message, chunksForRedeem);
+            logger.debug("[extractInternalRedeemScriptChunks] {} {}", message, chunks);
             throw new VerificationException(message);
         }
 
-        return chunksForRedeem;
+        return chunks.subList(2, chunks.size());
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -50,7 +50,7 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
     public static List<ScriptChunk> extractInternalRedeemScriptChunks(List<ScriptChunk> chunks) {
         if (chunks.size() <= 2) {
             String message = "Flyover redeem script obtained has an invalid structure";
-            logger.debug("[extractInternalRedeemScriptChunks] {} {}", message, chunks);
+            logger.debug("[extractInternalRedeemScriptChunks] {}", message);
             throw new VerificationException(message);
         }
 

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
@@ -13,7 +13,8 @@ public interface RedeemScriptParser {
         ERP_FED,
         FAST_BRIDGE_ERP_FED,
         P2SH_ERP_FED,
-        FAST_BRIDGE_P2SH_ERP_FED
+        FAST_BRIDGE_P2SH_ERP_FED,
+        FLYOVER
     }
 
     MultiSigType getMultiSigType();

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -39,6 +39,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getM_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnMValue() {
         // Arrange
+        final int EXPECTED_M = 5;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
@@ -48,12 +49,13 @@ public class FlyoverRedeemScriptParserTest {
         int actualM = flyoverRedeemScriptParser.getM();
 
         // Assert
-        assertEquals(5, actualM);
+        assertEquals(EXPECTED_M, actualM);
     }
 
     @Test
     public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
         // Arrange
+        final int EXPECTED_M = 5;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L
         );
@@ -64,12 +66,13 @@ public class FlyoverRedeemScriptParserTest {
         int actualM = flyoverRedeemScriptParser.getM();
 
         // Assert
-        assertEquals(5, actualM);
+        assertEquals(EXPECTED_M, actualM);
     }
 
     @Test
     public void getM_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnMValue() {
         // Arrange
+        final int EXPECTED_M = 5;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
         Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
@@ -79,7 +82,7 @@ public class FlyoverRedeemScriptParserTest {
         int actualM = flyoverRedeemScriptParser.getM();
 
         // Assert
-        assertEquals(5, actualM);
+        assertEquals(EXPECTED_M, actualM);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -41,7 +41,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -57,7 +57,7 @@ public class FlyoverRedeemScriptParserTest {
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L
         );
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -72,7 +72,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -87,7 +87,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -102,7 +102,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act / Assert
@@ -114,7 +114,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -129,7 +129,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -144,7 +144,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -159,7 +159,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         final NetworkParameters mainNetParams = MainNetParams.get();
@@ -193,7 +193,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
         List<ScriptChunk> expectedRedeemScriptChunks = standardRedeemScript.getChunks();
 
@@ -211,7 +211,7 @@ public class FlyoverRedeemScriptParserTest {
         List<ScriptChunk> expectedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(erpRedeemScript.getChunks());
 
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
@@ -228,7 +228,7 @@ public class FlyoverRedeemScriptParserTest {
         List<ScriptChunk> expectedRedeemScriptChunks = P2shErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(p2shErpRedeemScript.getChunks());
 
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -16,7 +16,6 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,8 +31,6 @@ public class FlyoverRedeemScriptParserTest {
     private Script flyoverErpRedeemScript;
     private Script p2shErpRedeemScript;
     private Script flyoverP2shErpRedeemScript;
-    private List<Script> malformedScripts;
-    private List<Script> flyoverRedeemScripts;
 
     @Before
     public void setUp() {
@@ -46,96 +43,159 @@ public class FlyoverRedeemScriptParserTest {
 
         p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, CSV_VALUE);
         flyoverP2shErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
-
-        flyoverRedeemScripts = Arrays.asList(flyoverStandardRedeemScript, flyoverErpRedeemScript, flyoverP2shErpRedeemScript);
-
-        Script malformedScriptZeroSize = new Script(new byte[0]);
-        Script malformedScriptTwoSize = new Script(new byte[2]);
-
-        malformedScripts = Arrays.asList(malformedScriptZeroSize, malformedScriptTwoSize);
     }
 
     @Test
-    public void getMultiSigType_whenIsValidRedeemScript_shouldReturnFlyoverMultiSigType() {
-        for(Script flyoverRedeemScript : flyoverRedeemScripts) {
-            // Arrange
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
-
-            // Act
-            MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
-
-            // Assert
-            assertEquals(MultiSigType.FLYOVER, actualMultiSigType);
-        }
+    public void getMultiSigType_whenIsStandardRedeemScript_shouldReturnFlyoverMultiSigType() {
+        assertIsFlyoverMultiSigType(flyoverStandardRedeemScript);
     }
 
     @Test
-    public void getM_whenFlyoverRedeemScriptContainsValidRedeemScript_shouldReturnMValue() {
+    public void getMultiSigType_whenIsErpRedeemScript_shouldReturnFlyoverMultiSigType() {
+        assertIsFlyoverMultiSigType(flyoverErpRedeemScript);
+    }
+
+    @Test
+    public void getMultiSigType_whenIsP2shErpRedeemScript_shouldReturnFlyoverMultiSigType() {
+        assertIsFlyoverMultiSigType(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertIsFlyoverMultiSigType(Script flyoverRedeemScript) {
+        // Arrange
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
+
+        // Assert
+        assertEquals(MultiSigType.FLYOVER, actualMultiSigType);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnMValue() {
+        assertGetMValue(flyoverStandardRedeemScript);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
+        assertGetMValue(flyoverErpRedeemScript);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnMValue() {
+        assertGetMValue(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertGetMValue(Script flyoverRedeemScript) {
         // Arrange
         final int EXPECTED_M = 5;
-        for (Script flyoverRedeemScript : flyoverRedeemScripts) {
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
-            // Act
-            int actualM = flyoverRedeemScriptParser.getM();
+        // Act
+        int actualM = flyoverRedeemScriptParser.getM();
 
-            // Assert
-            assertEquals(EXPECTED_M, actualM);
-        }
+        // Assert
+        assertEquals(EXPECTED_M, actualM);
     }
 
     @Test
-    public void findKeyInRedeem_whenKeyIsInRedeemScript_shouldReturnKeyIndexPosition() {
+    public void findKeyInRedeem_whenKeyIsInStandardRedeemScript_shouldReturnKeyIndexPosition() {
+        assertKeyInRedeem(flyoverStandardRedeemScript);
+    }
+
+    @Test
+    public void findKeyInRedeem_whenKeyIsInErpRedeemScript_shouldReturnKeyIndexPosition() {
+        assertKeyInRedeem(flyoverErpRedeemScript);
+    }
+
+    @Test
+    public void findKeyInRedeem_whenKeyIsInP2shErpRedeemScript_shouldReturnKeyIndexPosition() {
+        assertKeyInRedeem(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertKeyInRedeem(Script flyoverRedeemScript) {
         // Arrange
         final int EXPECTED_KEY_INDEX = 5;
-        for (Script flyoverRedeemScript : flyoverRedeemScripts) {
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
-            // Act
-            int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(EXPECTED_KEY_INDEX));
+        // Act
+        int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(EXPECTED_KEY_INDEX));
 
-            // Assert
-            assertEquals(EXPECTED_KEY_INDEX, actualKeyIndex);
-        }
+        // Assert
+        assertEquals(EXPECTED_KEY_INDEX, actualKeyIndex);
     }
 
-    @Test
-    public void findKeyInRedeem_whenKeyIsNotInRedeemScript_shouldThrowIllegalStateException() {
+    @Test(expected = IllegalStateException.class)
+    public void findKeyInRedeem_whenKeyIsNotInStandardRedeemScript_shouldThrowIllegalStateException() {
+        assertThrowsIllegalStateException(flyoverStandardRedeemScript);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void findKeyInRedeem_whenKeyIsNotInErpRedeemScript_shouldThrowIllegalStateException() {
+        assertThrowsIllegalStateException(flyoverErpRedeemScript);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void findKeyInRedeem_whenKeyIsNotInP2shErpRedeemScript_shouldThrowIllegalStateException() {
+        assertThrowsIllegalStateException(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertThrowsIllegalStateException(Script flyoverRedeemScript) {
         // Arrange
         final BtcECKey differentKey = BtcECKey.fromPrivate(BigInteger.valueOf(1000));
-        for(Script flyoverRedeemScript : flyoverRedeemScripts) {
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
-            try {
-                // Act
-                flyoverRedeemScriptParser.findKeyInRedeem(differentKey);
-            } catch (IllegalStateException actualException) {
-                // Assert
-                assertEquals(IllegalStateException.class, actualException.getClass());
-            }
-        }
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act - Assert
+        flyoverRedeemScriptParser.findKeyInRedeem(differentKey);
     }
 
     @Test
-    public void getPubKeys_whenFlyoverRedeemScriptContainsValidRedeemScript_shouldReturnPubKeys() {
-        for (Script flyoverRedeemScript : flyoverRedeemScripts) {
-            // Arrange
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
-
-            // Act
-            List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
-
-            // Assert
-            defaultRedeemScriptKeys.forEach(expectedPubKey -> {
-                int btcECKeyIndex = defaultRedeemScriptKeys.indexOf(expectedPubKey);
-                BtcECKey btcECKey = actualPubKeys.get(btcECKeyIndex);
-                byte[] actualPubKey = btcECKey.getPubKey();
-                assertThat(actualPubKey, equalTo(expectedPubKey.getPubKey()));
-            });
-        }
+    public void getPubKeys_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnPubKeys() {
+        assertPubKeys(flyoverStandardRedeemScript);
     }
 
     @Test
-    public void findSigInRedeem_whenSignatureIsInValidRedeemScript_shouldReturnSignatureIndexPosition() {
+    public void getPubKeys_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnPubKeys() {
+        assertPubKeys(flyoverErpRedeemScript);
+    }
+
+    @Test
+    public void getPubKeys_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnPubKeys() {
+        assertPubKeys(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertPubKeys(Script flyoverRedeemScript) {
+        // Arrange
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
+
+        // Assert
+        defaultRedeemScriptKeys.forEach(expectedPubKey -> {
+            int btcECKeyIndex = defaultRedeemScriptKeys.indexOf(expectedPubKey);
+            BtcECKey btcECKey = actualPubKeys.get(btcECKeyIndex);
+            byte[] actualPubKey = btcECKey.getPubKey();
+            assertThat(actualPubKey, equalTo(expectedPubKey.getPubKey()));
+        });
+    }
+
+    @Test
+    public void findSigInRedeem_whenSignatureIsInStandardRedeemScript_shouldReturnSignatureIndexPosition() {
+        assertSigInRedeem(flyoverStandardRedeemScript);
+    }
+
+    @Test
+    public void findSigInRedeem_whenSignatureIsInErpRedeemScript_shouldReturnSignatureIndexPosition() {
+        assertSigInRedeem(flyoverErpRedeemScript);
+    }
+
+    @Test
+    public void findSigInRedeem_whenSignatureIsInP2shErpRedeemScript_shouldReturnSignatureIndexPosition() {
+        assertSigInRedeem(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertSigInRedeem(Script flyoverRedeemScript){
         // Arrange
         final int EXPECTED_SIGNATURE_INDEX = 0;
         final int SIGNATURE_INPUT_INDEX = 0;
@@ -164,15 +224,13 @@ public class FlyoverRedeemScriptParserTest {
         ECDSASignature signature = privateKey.sign(hashForSignatureHash);
         TransactionSignature transactionSignature = new TransactionSignature(signature, BtcTransaction.SigHash.ALL, false);
 
-        for (Script flyoverRedeemScript : flyoverRedeemScripts) {
-            FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
-            // Act
-            int actualSignatureIndex = flyoverRedeemScriptParser.findSigInRedeem(transactionSignature.encodeToBitcoin(), hashForSignatureHash);
+        // Act
+        int actualSignatureIndex = flyoverRedeemScriptParser.findSigInRedeem(transactionSignature.encodeToBitcoin(), hashForSignatureHash);
 
-            // Assert
-            assertEquals(EXPECTED_SIGNATURE_INDEX, actualSignatureIndex);
-        }
+        // Assert
+        assertEquals(EXPECTED_SIGNATURE_INDEX, actualSignatureIndex);
     }
 
     @Test
@@ -214,16 +272,19 @@ public class FlyoverRedeemScriptParserTest {
         assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
     }
 
-    @Test
-    public void flyoverRedeemScriptParser_whenRedeemScriptChunksIsMalformed_shouldThrowVerificationException(){
-        for (Script script : malformedScripts) {
-            try {
-                // Act
-                new FlyoverRedeemScriptParser(script.getChunks());
-            } catch (VerificationException actualException) {
-                // Assert
-                assertEquals(VerificationException.class, actualException.getClass());
-            }
-        }
+    @Test(expected = VerificationException.class)
+    public void flyoverRedeemScriptParser_whenRedeemScriptChunksSizeIsZero_shouldThrowVerificationException(){
+        Script malformedScriptZeroSize = new Script(new byte[0]);
+
+        // Act
+        new FlyoverRedeemScriptParser(malformedScriptZeroSize.getChunks());
+    }
+
+    @Test(expected = VerificationException.class)
+    public void flyoverRedeemScriptParser_whenRedeemScriptChunksSizeIsTwo_shouldThrowVerificationException(){
+        Script malformedScriptTwoSize = new Script(new byte[2]);
+
+        // Act
+        new FlyoverRedeemScriptParser(malformedScriptTwoSize.getChunks());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -16,20 +16,37 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
 import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 
 public class FlyoverRedeemScriptParserTest {
 
     private final List<BtcECKey> defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
     private final List<BtcECKey> emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+    private final Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+    private Script standardRedeemScript;
+    private Script flyoverStandardRedeemScript;
+    private Script erpRedeemScript;
+    private Script flyoverErpRedeemScript;
+    private Script p2shErpRedeemScript;
+    private Script flyoverP2shErpRedeemScript;
+
+    @Before
+    public void setUp() {
+        standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        flyoverStandardRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
+
+        erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        flyoverErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
+
+        p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        flyoverP2shErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
+    }
 
     @Test
     public void getMultiSigType_whenIsStandardRedeemScript_shouldReturnFlyoverMultiSigType() {
         // Arrange
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
@@ -41,10 +58,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getMultiSigType_whenIsErpRedeemScript_shouldReturnFlyoverMultiSigType() {
         // Arrange
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
 
         // Act
         MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
@@ -56,10 +70,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getMultiSigType_whenIsP2shErpRedeemScript_shouldReturnFlyoverMultiSigType() {
         // Arrange
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverP2shErpRedeemScript.getChunks());
 
         // Act
         MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
@@ -72,10 +83,7 @@ public class FlyoverRedeemScriptParserTest {
     public void getM_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnMValue() {
         // Arrange
         final int EXPECTED_M = 5;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         int actualM = flyoverRedeemScriptParser.getM();
@@ -88,10 +96,7 @@ public class FlyoverRedeemScriptParserTest {
     public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
         // Arrange
         final int EXPECTED_M = 5;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
 
         // Act
         int actualM = flyoverRedeemScriptParser.getM();
@@ -104,10 +109,7 @@ public class FlyoverRedeemScriptParserTest {
     public void getM_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnMValue() {
         // Arrange
         final int EXPECTED_M = 5;
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverP2shErpRedeemScript.getChunks());
 
         // Act
         int actualM = flyoverRedeemScriptParser.getM();
@@ -119,10 +121,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void findKeyInRedeem_whenKeyIsInRedeemScript_shouldReturnKeyIndexPosition() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(0));
@@ -134,10 +133,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test(expected = IllegalStateException.class)
     public void findKeyInRedeem_whenKeyIsNotInRedeemScript_shouldThrowIllegalStateException() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act / Assert
         flyoverRedeemScriptParser.findKeyInRedeem(emergencyRedeemScriptKeys.get(0));
@@ -146,10 +142,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getPubKeys_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnPubKeys() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
@@ -163,10 +156,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getPubKeys_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnPubKeys() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
 
         // Act
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
@@ -180,10 +170,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getPubKeys_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnPubKeys() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverP2shErpRedeemScript.getChunks());
 
         // Act
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
@@ -204,10 +191,7 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void findSigInRedeem_whenSignatureIsInRedeemScript_shouldReturnSignatureIndexPosition() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         final NetworkParameters mainNetParams = MainNetParams.get();
         BtcECKey privateKey = defaultRedeemScriptKeys.get(0);
@@ -223,7 +207,8 @@ public class FlyoverRedeemScriptParserTest {
             0,
             standardRedeemScript,
             BtcTransaction.SigHash.ALL,
-            false);
+            false
+        );
 
         ECDSASignature signature = privateKey.sign(hashForSignatureHash);
         TransactionSignature transactionSignature = new TransactionSignature(signature, BtcTransaction.SigHash.ALL, false);
@@ -238,11 +223,8 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void extractStandardRedeemScriptChunks_whenIsStandardRedeemScript_shouldReturnStandardRedeemScriptChunks() {
         // Arrange
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
         List<ScriptChunk> expectedRedeemScriptChunks = standardRedeemScript.getChunks();
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
@@ -254,12 +236,8 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void extractStandardRedeemScriptChunks_whenIsErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
         // Arrange
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
         List<ScriptChunk> expectedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(erpRedeemScript.getChunks());
-
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
 
         // Act
         List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
@@ -271,12 +249,8 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void extractStandardRedeemScriptChunks_whenIsP2shErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
         // Arrange
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
         List<ScriptChunk> expectedRedeemScriptChunks = P2shErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(p2shErpRedeemScript.getChunks());
-
-        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverP2shErpRedeemScript.getChunks());
 
         // Act
         List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -254,56 +254,6 @@ public class FlyoverRedeemScriptParserTest {
         assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
     }
 
-    @Test
-    public void extractInternalRedeemScriptChunks_whenIsStandardRedeemScript_shouldReturnStandardRedeemScriptChunks() {
-        // Arrange
-        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
-        List<ScriptChunk> expectedRedeemScriptChunks = standardRedeemScriptChunks.subList(2, standardRedeemScriptChunks.size());
-
-        // Act
-        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(standardRedeemScriptChunks);
-
-        // Assert
-        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
-    }
-
-    @Test
-    public void extractInternalRedeemScriptChunks_whenIsErpRedeemScript_shouldReturnErpRedeemScriptChunks(){
-        // Arrange
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L
-        );
-        List<ScriptChunk> erpRedeemScriptChunks = erpRedeemScript.getChunks();
-        List<ScriptChunk> expectedRedeemScriptChunks = erpRedeemScriptChunks.subList(2, erpRedeemScript.getChunks().size());
-
-        // Act
-        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(erpRedeemScript.getChunks());
-
-        // Assert
-        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
-    }
-
-    @Test
-    public void extractInternalRedeemScriptChunks_whenIsP2shErpRedeemScript_shouldReturnP2shErpRedeemScript(){
-        // Arrange
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L
-        );
-        List<ScriptChunk> p2shErpRedeemScriptChunks = p2shErpRedeemScript.getChunks();
-        List<ScriptChunk> expectedRedeemScriptChunks = p2shErpRedeemScriptChunks.subList(2, p2shErpRedeemScript.getChunks().size());
-
-        // Act
-        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(p2shErpRedeemScript.getChunks());
-
-        // Assert
-        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
-    }
-
     @Test(expected = VerificationException.class)
     public void extractInternalRedeemScriptChunks_whenRedeemScriptChunksSizeIsZero_shouldThrowVerificationException(){
         // Arrange
@@ -311,7 +261,8 @@ public class FlyoverRedeemScriptParserTest {
         List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
 
         // Act / Assert
-        FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(redeemScriptChunks);
+        // Executed the private method extractInternalRedeemScriptChunks through the constructor
+        new FlyoverRedeemScriptParser(redeemScriptChunks);
     }
 
     @Test(expected = VerificationException.class)
@@ -321,6 +272,7 @@ public class FlyoverRedeemScriptParserTest {
         List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
 
         // Act / Assert
-        FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(redeemScriptChunks);
+        // Executed the private method extractInternalRedeemScriptChunks through the constructor
+        new FlyoverRedeemScriptParser(redeemScriptChunks);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -138,8 +138,10 @@ public class FlyoverRedeemScriptParserTest {
     public void findSigInRedeem_whenSignatureIsInValidRedeemScript_shouldReturnSignatureIndexPosition() {
         // Arrange
         final int EXPECTED_SIGNATURE_INDEX = 0;
+        final int SIGNATURE_INPUT_INDEX = 0;
+        final int OUTPUT_INDEX = 0;
         final NetworkParameters mainNetParams = MainNetParams.get();
-        BtcECKey privateKey = defaultRedeemScriptKeys.get(EXPECTED_SIGNATURE_INDEX);
+        BtcECKey privateKey = defaultRedeemScriptKeys.get(SIGNATURE_INPUT_INDEX);
 
         // Creating a transaction
         BtcTransaction fundTx = new BtcTransaction(mainNetParams);
@@ -147,11 +149,11 @@ public class FlyoverRedeemScriptParserTest {
         fundTx.addOutput(Coin.FIFTY_COINS, userAddress);
 
         BtcTransaction spendTx = new BtcTransaction(mainNetParams);
-        spendTx.addInput(fundTx.getOutput(EXPECTED_SIGNATURE_INDEX));
+        spendTx.addInput(fundTx.getOutput(OUTPUT_INDEX));
 
         // Getting the transaction hash for the signature
         Sha256Hash hashForSignatureHash = spendTx.hashForSignature(
-            EXPECTED_SIGNATURE_INDEX,
+            SIGNATURE_INPUT_INDEX,
             standardRedeemScript,
             BtcTransaction.SigHash.ALL,
             false

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -122,13 +122,14 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void findKeyInRedeem_whenKeyIsInRedeemScript_shouldReturnKeyIndexPosition() {
         // Arrange
+        final int EXPECTED_KEY_INDEX = 5;
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
-        int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(0));
+        int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(EXPECTED_KEY_INDEX));
 
         // Assert
-        assertEquals(0, actualKeyIndex);
+        assertEquals(EXPECTED_KEY_INDEX, actualKeyIndex);
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -27,7 +27,39 @@ public class FlyoverRedeemScriptParserTest {
     public void getMultiSigType_whenIsStandardRedeemScript_shouldReturnFlyoverMultiSigType() {
         // Arrange
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(standardRedeemScript.getChunks());
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
+
+        // Assert
+        assertEquals(MultiSigType.FLYOVER, actualMultiSigType);
+    }
+
+    @Test
+    public void getMultiSigType_whenIsErpRedeemScript_shouldReturnFlyoverMultiSigType() {
+        // Arrange
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
+
+        // Assert
+        assertEquals(MultiSigType.FLYOVER, actualMultiSigType);
+    }
+
+    @Test
+    public void getMultiSigType_whenIsP2shErpRedeemScript_shouldReturnFlyoverMultiSigType() {
+        // Arrange
+        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 
         // Act
         MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
@@ -57,8 +89,7 @@ public class FlyoverRedeemScriptParserTest {
         // Arrange
         final int EXPECTED_M = 5;
         Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L
-        );
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
         Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
 

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 public class FlyoverRedeemScriptParserTest {
 
+    private static final int EXPECTED_M = 5;
     private final List<BtcECKey> defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
     private final List<BtcECKey> emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
     private final Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
@@ -84,7 +85,6 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getM_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnMValue() {
         // Arrange
-        final int EXPECTED_M = 5;
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
@@ -97,7 +97,6 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
         // Arrange
-        final int EXPECTED_M = 5;
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
 
         // Act
@@ -110,7 +109,6 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void getM_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnMValue() {
         // Arrange
-        final int EXPECTED_M = 5;
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverP2shErpRedeemScript.getChunks());
 
         // Act

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -33,13 +33,14 @@ public class FlyoverRedeemScriptParserTest {
 
     @Before
     public void setUp() {
+        final long CSV_VALUE = 52_560L;
         standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         flyoverStandardRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript);
 
-        erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, CSV_VALUE);
         flyoverErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript);
 
-        p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, CSV_VALUE);
         flyoverP2shErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript);
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -191,8 +191,6 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void findSigInRedeem_whenSignatureIsInRedeemScript_shouldReturnSignatureIndexPosition() {
         // Arrange
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
-
         final NetworkParameters mainNetParams = MainNetParams.get();
         BtcECKey privateKey = defaultRedeemScriptKeys.get(0);
 
@@ -212,6 +210,8 @@ public class FlyoverRedeemScriptParserTest {
 
         ECDSASignature signature = privateKey.sign(hashForSignatureHash);
         TransactionSignature transactionSignature = new TransactionSignature(signature, BtcTransaction.SigHash.ALL, false);
+
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act
         int actualSignatureIndex = flyoverRedeemScriptParser.findSigInRedeem(transactionSignature.encodeToBitcoin(), hashForSignatureHash);

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -3,7 +3,6 @@ package co.rsk.bitcoinj.script;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -193,8 +193,9 @@ public class FlyoverRedeemScriptParserTest {
     @Test
     public void findSigInRedeem_whenSignatureIsInRedeemScript_shouldReturnSignatureIndexPosition() {
         // Arrange
+        final int EXPECTED_SIGNATURE_INDEX = 0;
         final NetworkParameters mainNetParams = MainNetParams.get();
-        BtcECKey privateKey = defaultRedeemScriptKeys.get(0);
+        BtcECKey privateKey = defaultRedeemScriptKeys.get(EXPECTED_SIGNATURE_INDEX);
 
         // Creating a transaction
         BtcTransaction fundTx = new BtcTransaction(mainNetParams);
@@ -202,11 +203,11 @@ public class FlyoverRedeemScriptParserTest {
         fundTx.addOutput(Coin.FIFTY_COINS, userAddress);
 
         BtcTransaction spendTx = new BtcTransaction(mainNetParams);
-        spendTx.addInput(fundTx.getOutput(0));
+        spendTx.addInput(fundTx.getOutput(EXPECTED_SIGNATURE_INDEX));
 
         // Getting the transaction hash for the signature
         Sha256Hash hashForSignatureHash = spendTx.hashForSignature(
-            0,
+            EXPECTED_SIGNATURE_INDEX,
             standardRedeemScript,
             BtcTransaction.SigHash.ALL,
             false
@@ -222,7 +223,7 @@ public class FlyoverRedeemScriptParserTest {
         int actualSignatureIndex = flyoverRedeemScriptParser.findSigInRedeem(transactionSignature.encodeToBitcoin(), hashForSignatureHash);
 
         // Assert
-        assertEquals(0, actualSignatureIndex);
+        assertEquals(EXPECTED_SIGNATURE_INDEX, actualSignatureIndex);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -140,8 +140,9 @@ public class FlyoverRedeemScriptParserTest {
         final int EXPECTED_SIGNATURE_INDEX = 0;
         final int SIGNATURE_INPUT_INDEX = 0;
         final int OUTPUT_INDEX = 0;
+        final int KEY_INDEX = 0;
         final NetworkParameters mainNetParams = MainNetParams.get();
-        BtcECKey privateKey = defaultRedeemScriptKeys.get(SIGNATURE_INPUT_INDEX);
+        BtcECKey privateKey = defaultRedeemScriptKeys.get(KEY_INDEX);
 
         // Creating a transaction
         BtcTransaction fundTx = new BtcTransaction(mainNetParams);

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -15,6 +15,7 @@ import co.rsk.bitcoinj.core.VerificationException;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.MainNetParams;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
+import java.math.BigInteger;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -135,10 +136,11 @@ public class FlyoverRedeemScriptParserTest {
     @Test(expected = IllegalStateException.class)
     public void findKeyInRedeem_whenKeyIsNotInRedeemScript_shouldThrowIllegalStateException() {
         // Arrange
+        final BtcECKey differentKey = BtcECKey.fromPrivate(BigInteger.valueOf(1000));
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverStandardRedeemScript.getChunks());
 
         // Act / Assert
-        flyoverRedeemScriptParser.findKeyInRedeem(emergencyRedeemScriptKeys.get(0));
+        flyoverRedeemScriptParser.findKeyInRedeem(differentKey);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -1,0 +1,269 @@
+package co.rsk.bitcoinj.script;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.VerificationException;
+import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
+import java.util.List;
+import org.junit.Test;
+
+public class FlyoverRedeemScriptParserTest {
+
+    private final List<BtcECKey> defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
+    private final List<BtcECKey> emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+
+    @Test
+    public void getMultiSigType_fromStandardRedeemScript() {
+        // Arrange
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(standardRedeemScript.getChunks());
+
+        // Act
+        MultiSigType actualMultiSigType = flyoverRedeemScriptParser.getMultiSigType();
+
+        // Assert
+        assertEquals(MultiSigType.FLYOVER, actualMultiSigType);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnMValue() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        int actualM = flyoverRedeemScriptParser.getM();
+
+        // Assert
+        assertEquals(5, actualM);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L
+        );
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        int actualM = flyoverRedeemScriptParser.getM();
+
+        // Assert
+        assertEquals(5, actualM);
+    }
+
+    @Test
+    public void getM_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnMValue() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        int actualM = flyoverRedeemScriptParser.getM();
+
+        // Assert
+        assertEquals(5, actualM);
+    }
+
+    @Test
+    public void findKeyInRedeem_whenKeyIsInRedeemScript_shouldReturnKeyIndexPosition() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        int actualKeyIndex = flyoverRedeemScriptParser.findKeyInRedeem(defaultRedeemScriptKeys.get(0));
+
+        // Assert
+        assertEquals(0, actualKeyIndex);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void findKeyInRedeem_whenKeyIsNotInRedeemScript_shouldThrowIllegalStateException() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act / Assert
+        flyoverRedeemScriptParser.findKeyInRedeem(emergencyRedeemScriptKeys.get(0));
+    }
+
+    @Test
+    public void getPubKeys_whenFlyoverRedeemScriptContainsStandardRedeemScript_shouldReturnPubKeys() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
+
+        // Assert
+        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+    }
+
+    @Test
+    public void getPubKeys_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnPubKeys() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
+
+        // Assert
+        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+    }
+
+    @Test
+    public void getPubKeys_whenFlyoverRedeemScriptContainsP2shErpRedeemScript_shouldReturnPubKeys() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
+
+        // Assert
+        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+    }
+
+    @Test
+    public void extractStandardRedeemScriptChunks_whenIsStandardRedeemScript_shouldReturnStandardRedeemScriptChunks() {
+        // Arrange
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), standardRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+        List<ScriptChunk> expectedRedeemScriptChunks = standardRedeemScript.getChunks();
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void extractStandardRedeemScriptChunks_whenIsErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
+        // Arrange
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        List<ScriptChunk> expectedRedeemScriptChunks = ErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(erpRedeemScript.getChunks());
+
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), erpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void extractStandardRedeemScriptChunks_whenIsP2shErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
+        // Arrange
+        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(defaultRedeemScriptKeys, emergencyRedeemScriptKeys, 500L);
+        List<ScriptChunk> expectedRedeemScriptChunks = P2shErpFederationRedeemScriptParser.extractStandardRedeemScriptChunks(p2shErpRedeemScript.getChunks());
+
+        Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
+        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(derivationArgumentsHash.getBytes(), p2shErpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void extractInternalRedeemScriptChunks_whenIsStandardRedeemScript_shouldReturnStandardRedeemScriptChunks() {
+        // Arrange
+        Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+        List<ScriptChunk> standardRedeemScriptChunks = standardRedeemScript.getChunks();
+        List<ScriptChunk> expectedRedeemScriptChunks = standardRedeemScriptChunks.subList(2, standardRedeemScriptChunks.size());
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(standardRedeemScriptChunks);
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void extractInternalRedeemScriptChunks_whenIsErpRedeemScript_shouldReturnErpRedeemScriptChunks(){
+        // Arrange
+        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
+            defaultRedeemScriptKeys,
+            emergencyRedeemScriptKeys,
+            500L
+        );
+        List<ScriptChunk> erpRedeemScriptChunks = erpRedeemScript.getChunks();
+        List<ScriptChunk> expectedRedeemScriptChunks = erpRedeemScriptChunks.subList(2, erpRedeemScript.getChunks().size());
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(erpRedeemScript.getChunks());
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void extractInternalRedeemScriptChunks_whenIsP2shErpRedeemScript_shouldReturnP2shErpRedeemScript(){
+        // Arrange
+        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
+            defaultRedeemScriptKeys,
+            emergencyRedeemScriptKeys,
+            500L
+        );
+        List<ScriptChunk> p2shErpRedeemScriptChunks = p2shErpRedeemScript.getChunks();
+        List<ScriptChunk> expectedRedeemScriptChunks = p2shErpRedeemScriptChunks.subList(2, p2shErpRedeemScript.getChunks().size());
+
+        // Act
+        List<ScriptChunk> actualRedeemScriptChunks = FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(p2shErpRedeemScript.getChunks());
+
+        // Assert
+        assertEquals(expectedRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void extractInternalRedeemScriptChunks_whenRedeemScriptChunksSizeIsZero_shouldThrowVerificationException(){
+        // Arrange
+        Script redeemScript = new Script(new byte[0]);
+        List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
+
+        // Act / Assert
+        FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(redeemScriptChunks);
+    }
+
+    @Test(expected = VerificationException.class)
+    public void extractInternalRedeemScriptChunks_whenRedeemScriptChunksSizeIsTwo_shouldThrowVerificationException(){
+        // Arrange
+        Script redeemScript = new Script(new byte[2]);
+        List<ScriptChunk> redeemScriptChunks = redeemScript.getChunks();
+
+        // Act / Assert
+        FlyoverRedeemScriptParser.extractInternalRedeemScriptChunks(redeemScriptChunks);
+    }
+}

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -194,6 +194,7 @@ public class FlyoverRedeemScriptParserTest {
         final NetworkParameters mainNetParams = MainNetParams.get();
         BtcECKey privateKey = defaultRedeemScriptKeys.get(0);
 
+        // Creating a transaction
         BtcTransaction fundTx = new BtcTransaction(mainNetParams);
         Address userAddress = privateKey.toAddress(mainNetParams);
         fundTx.addOutput(Coin.FIFTY_COINS, userAddress);
@@ -201,6 +202,7 @@ public class FlyoverRedeemScriptParserTest {
         BtcTransaction spendTx = new BtcTransaction(mainNetParams);
         spendTx.addInput(fundTx.getOutput(0));
 
+        // Getting the transaction hash for the signature
         Sha256Hash hashForSignatureHash = spendTx.hashForSignature(
             0,
             standardRedeemScript,
@@ -208,6 +210,7 @@ public class FlyoverRedeemScriptParserTest {
             false
         );
 
+        // Signing the transaction hash
         ECDSASignature signature = privateKey.sign(hashForSignatureHash);
         TransactionSignature transactionSignature = new TransactionSignature(signature, BtcTransaction.SigHash.ALL, false);
 

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -124,7 +124,9 @@ public class FlyoverRedeemScriptParserTest {
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
 
         // Assert
-        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+        defaultRedeemScriptKeys.forEach(
+            expectedPubKey -> assertPublicKey(expectedPubKey, actualPubKeys)
+        );
     }
 
     @Test
@@ -139,7 +141,9 @@ public class FlyoverRedeemScriptParserTest {
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
 
         // Assert
-        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+        defaultRedeemScriptKeys.forEach(
+            expectedPubKey -> assertPublicKey(expectedPubKey, actualPubKeys)
+        );
     }
 
     @Test
@@ -154,7 +158,16 @@ public class FlyoverRedeemScriptParserTest {
         List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
 
         // Assert
-        defaultRedeemScriptKeys.forEach(key -> assertThat(actualPubKeys.get(defaultRedeemScriptKeys.indexOf(key)).getPubKey(), equalTo(key.getPubKey())));
+        defaultRedeemScriptKeys.forEach(
+            expectedPubKey -> assertPublicKey(expectedPubKey, actualPubKeys)
+        );
+    }
+
+    private void assertPublicKey(BtcECKey expectedPubKey, List<BtcECKey> actualPubKeys) {
+        int btcECKeyIndex = defaultRedeemScriptKeys.indexOf(expectedPubKey);
+        BtcECKey btcECKey = actualPubKeys.get(btcECKeyIndex);
+        byte[] actualPubKey = btcECKey.getPubKey();
+        assertThat(actualPubKey, equalTo(expectedPubKey.getPubKey()));
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -125,17 +125,13 @@ public class FlyoverRedeemScriptParserTest {
             List<BtcECKey> actualPubKeys = flyoverRedeemScriptParser.getPubKeys();
 
             // Assert
-            defaultRedeemScriptKeys.forEach(
-                expectedPubKey -> assertPublicKey(expectedPubKey, actualPubKeys)
-            );
+            defaultRedeemScriptKeys.forEach(expectedPubKey -> {
+                int btcECKeyIndex = defaultRedeemScriptKeys.indexOf(expectedPubKey);
+                BtcECKey btcECKey = actualPubKeys.get(btcECKeyIndex);
+                byte[] actualPubKey = btcECKey.getPubKey();
+                assertThat(actualPubKey, equalTo(expectedPubKey.getPubKey()));
+            });
         }
-    }
-
-    private void assertPublicKey(BtcECKey expectedPubKey, List<BtcECKey> actualPubKeys) {
-        int btcECKeyIndex = defaultRedeemScriptKeys.indexOf(expectedPubKey);
-        BtcECKey btcECKey = actualPubKeys.get(btcECKeyIndex);
-        byte[] actualPubKey = btcECKey.getPubKey();
-        assertThat(actualPubKey, equalTo(expectedPubKey.getPubKey()));
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -24,7 +24,7 @@ public class FlyoverRedeemScriptParserTest {
     private final List<BtcECKey> emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
 
     @Test
-    public void getMultiSigType_fromStandardRedeemScript() {
+    public void getMultiSigType_whenIsStandardRedeemScript_shouldReturnFlyoverMultiSigType() {
         // Arrange
         Script standardRedeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
         FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(standardRedeemScript.getChunks());

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
@@ -8,13 +8,16 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
-public class RedeemScriptUtils {
+public final class RedeemScriptUtils {
 
-    protected static Script createStandardRedeemScript(List<BtcECKey> publicKeys) {
+    private RedeemScriptUtils() {
+    }
+
+    public static Script createStandardRedeemScript(List<BtcECKey> publicKeys) {
         return ScriptBuilder.createRedeemScript(publicKeys.size() / 2 + 1, publicKeys);
     }
 
-    protected static Script createFastBridgeRedeemScript(
+    public static Script createFastBridgeRedeemScript(
         byte[] derivationArgumentsHashBytes,
         List<BtcECKey> publicKeys
     ) {
@@ -31,7 +34,7 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static Script createFastBridgeErpRedeemScript(
+    public static Script createFastBridgeErpRedeemScript(
         List<BtcECKey> defaultRedeemScriptKeys,
         List<BtcECKey> emergencyRedeemScriptKeys,
         Long csvValue,
@@ -52,7 +55,7 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static Script createFastBridgeP2shErpRedeemScript(
+    public static Script createFastBridgeP2shErpRedeemScript(
         List<BtcECKey> defaultRedeemScriptKeys,
         List<BtcECKey> emergencyRedeemScriptKeys,
         Long csvValue,
@@ -73,7 +76,7 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static Script createCustomRedeemScript(List<BtcECKey> publicKeys) {
+    public static Script createCustomRedeemScript(List<BtcECKey> publicKeys) {
         Script redeem = ScriptBuilder.createRedeemScript(
             publicKeys.size() / 2 + 1,
             publicKeys
@@ -86,7 +89,7 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static Script createErpRedeemScript(
+    public static Script createErpRedeemScript(
         List<BtcECKey> defaultRedeemScriptKeys,
         List<BtcECKey> emergencyRedeemScriptKeys,
         Long csvValue
@@ -117,7 +120,7 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static Script createP2shErpRedeemScript(
+    public static Script createP2shErpRedeemScript(
         List<BtcECKey> defaultRedeemScriptKeys,
         List<BtcECKey> emergencyRedeemScriptKeys,
         Long csvValue
@@ -147,7 +150,16 @@ public class RedeemScriptUtils {
             .build();
     }
 
-    protected static List<BtcECKey> getDefaultRedeemScriptKeys() {
+    public static Script createFlyoverRedeemScript(byte[] derivationArgumentsHashBytes, List<ScriptChunk> redeemScriptChunks) {
+        ScriptBuilder scriptBuilder = new ScriptBuilder();
+        return scriptBuilder
+            .data(derivationArgumentsHashBytes)
+            .op(ScriptOpCodes.OP_DROP)
+            .addChunks(redeemScriptChunks)
+            .build();
+    }
+
+    public static List<BtcECKey> getDefaultRedeemScriptKeys() {
         List<BtcECKey> keys = Arrays.asList(
             BtcECKey.fromPrivate(BigInteger.valueOf(100)),
             BtcECKey.fromPrivate(BigInteger.valueOf(200)),
@@ -164,7 +176,7 @@ public class RedeemScriptUtils {
         return keys;
     }
 
-    protected static List<BtcECKey> getEmergencyRedeemScriptKeys() {
+    public static List<BtcECKey> getEmergencyRedeemScriptKeys() {
         List<BtcECKey> keys = Arrays.asList(
             BtcECKey.fromPrivate(BigInteger.valueOf(101)),
             BtcECKey.fromPrivate(BigInteger.valueOf(202)),

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptUtils.java
@@ -150,12 +150,13 @@ public final class RedeemScriptUtils {
             .build();
     }
 
-    public static Script createFlyoverRedeemScript(byte[] derivationArgumentsHashBytes, List<ScriptChunk> redeemScriptChunks) {
+    public static Script createFlyoverRedeemScript(byte[] derivationArgumentsHashBytes, Script internalRedeemScript) {
+        List<ScriptChunk> internalRedeemScriptChunks = internalRedeemScript.getChunks();
         ScriptBuilder scriptBuilder = new ScriptBuilder();
         return scriptBuilder
             .data(derivationArgumentsHashBytes)
             .op(ScriptOpCodes.OP_DROP)
-            .addChunks(redeemScriptChunks)
+            .addChunks(internalRedeemScriptChunks)
             .build();
     }
 


### PR DESCRIPTION
## Description

For every different federation type (standard multisig, legacy ERP, p2sh), there is a specific Flyover Redeem Script Parser. This is unnecessary since a flyover redeem script does not care about the federation redeem script format. It can take any redeem script and only needs the derivation hash and `OP_DROP` `opCode` on the top.

Create a `FlyoverRedeemScriptParser` class that implements the `RedeemScriptParser` interface and has a `RedeemScriptParser` attribute. It's the `RedeemScriptParserFactory` responsible for identifying the script as a FlyoverRedeemScriptParser, removing the first 2 `chunks` from it, and parsing the remaining chunks. The `FlyoverRedeemScriptParser` constructor will receive the full list of `chunks` that form the redeem script along with a `RedeemScriptParser` instance that represents the internal redeem script.

## Motivation and Context
This relates to the Reactors to add `SegwitRedeemScriptParser`.


## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
