### PR TITLE
Refactor RedeemScriptParserFactory to parse only redeem script types

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -10,26 +10,26 @@ public class RedeemScriptParserFactory {
     private static final byte[] NON_STANDARD_ERP_TESTNET_REDEEM_SCRIPT_SERIALIZED = Utils.HEX.decode("6453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f42102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a0921039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb955670300cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368ae");
     private static final Logger logger = LoggerFactory.getLogger(RedeemScriptParserFactory.class);
 
+
     private RedeemScriptParserFactory() { }
 
-    public static RedeemScriptParser get(List<ScriptChunk> chunks) {
+    public static RedeemScriptParser get(List<ScriptChunk> redeemScriptChunks) {
         // Due to a validation error, during the time this federation existed in testnet
         // bitcoinj-thin would not detect it correctly as an ERP fed
         // We need to keep this behaviour for the given redeem script to keep the consensus in testnet
         List<ScriptChunk> nonStandardErpTestnetRedeemScriptChunks = ScriptParser.parseScriptProgram(
             NON_STANDARD_ERP_TESTNET_REDEEM_SCRIPT_SERIALIZED);
-        if (nonStandardErpTestnetRedeemScriptChunks.equals(chunks)) {
+        if (nonStandardErpTestnetRedeemScriptChunks.equals(redeemScriptChunks)) {
             logger.debug("[get] Received redeem script matches the testnet federation hardcoded one. Return NonStandardErpRedeemScriptParserHardcoded");
             return new NonStandardErpRedeemScriptParserHardcoded();
         }
 
-        if (chunks.size() < 4) {
-            // A multisig redeem script must have at least 4 chunks (OP_N [PUB1 ...] OP_N CHECK_MULTISIG)
-            logger.trace("[get] Less than 4 chunks, return NonStandardErpRedeemScriptParserHardcoded");
-            return new NonStandardErpRedeemScriptParserHardcoded();
+        if (redeemScriptChunks.size() < 4) {
+            // A multisig redeem script must have at least 4 redeemScriptChunks (OP_N [PUB1 ...] OP_N CHECK_MULTISIG)
+            final String errorMessage = "The provided redeem script has less than 4 redeemScriptChunks.";
+            logger.trace(String.format("[get] %s", errorMessage));
+            throw new ScriptException(errorMessage);
         }
-
-        List<ScriptChunk> redeemScriptChunks = extractRedeemScriptFromChunks(chunks);
 
         if (FastBridgeRedeemScriptParser.isFastBridgeMultiSig(redeemScriptChunks)) {
             logger.debug("[get] Return FastBridgeRedeemScriptParser");
@@ -68,29 +68,7 @@ public class RedeemScriptParserFactory {
             );
         }
 
-        logger.debug("[get] Return NonStandardErpRedeemScriptParserHardcoded");
-        return new NonStandardErpRedeemScriptParserHardcoded();
-    }
-
-    private static List<ScriptChunk> extractRedeemScriptFromChunks(List<ScriptChunk> chunks) {
-        ScriptChunk lastChunk = chunks.get(chunks.size() - 1);
-        if (RedeemScriptValidator.isRedeemLikeScript(chunks)) {
-            return chunks;
-        }
-        if (lastChunk.data != null && lastChunk.data.length > 0) {
-            int lastByte = lastChunk.data[lastChunk.data.length - 1] & 0xff;
-            // ERP and standard (+fastBridge) finish with OP_CHECKMULTISIG and P2SHERP (+fastBridge) finish with OP_ENDIF
-            if (
-                    lastByte == ScriptOpCodes.OP_CHECKMULTISIG ||
-                    lastByte == ScriptOpCodes.OP_CHECKMULTISIGVERIFY ||
-                    lastByte == ScriptOpCodes.OP_ENDIF
-            ) {
-                return ScriptParser.parseScriptProgram(lastChunk.data);
-            }
-        }
-
-        String parsingErrorMessage = "Could not get redeem script from given chunks";
-        logger.debug("[extractRedeemScriptFromChunks] {}", parsingErrorMessage);
-        throw new ScriptException(parsingErrorMessage);
+        logger.debug("[get] Cannot parse provided redeem script");
+        throw new ScriptException("The provided redeem script is unknown");
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/Script.java
+++ b/src/main/java/co/rsk/bitcoinj/script/Script.java
@@ -681,7 +681,11 @@ public class Script {
      * Returns whether this script matches the format used for multisig outputs: [n] [keys...] [m] CHECKMULTISIG
      */
     public boolean isSentToMultiSig() {
-        return !this.getRedeemScriptParser().getMultiSigType().equals(MultiSigType.NO_MULTISIG_TYPE);
+        try {
+            return !this.getRedeemScriptParser().getMultiSigType().equals(MultiSigType.NO_MULTISIG_TYPE);
+        } catch (ScriptException e) {
+            return false;
+        }
     }
 
     public boolean isSentToCLTVPaymentChannel() {

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -4,6 +4,7 @@ import static co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType.NO_MULTISIG
 import static co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType.STANDARD_MULTISIG;
 
 import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
@@ -27,6 +28,12 @@ public class RedeemScriptParserFactoryTest {
     public void setUp() {
         defaultRedeemScriptKeys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
         emergencyRedeemScriptKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
+    }
+
+    @Test(expected = ScriptException.class)
+    public void get_whenMalformedMultiSig_shouldFail() {
+        Script redeemScript = new Script(new byte[2]);
+        RedeemScriptParserFactory.get(redeemScript.getChunks());
     }
 
     @Test
@@ -103,7 +110,7 @@ public class RedeemScriptParserFactoryTest {
         Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_fast_bridge_P2SH_chunk() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
         Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
@@ -117,12 +124,10 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_standard_P2SH_chunk() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
 
@@ -132,12 +137,10 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, redeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(STANDARD_MULTISIG, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_erp_P2SH_chunk() {
         Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
@@ -151,12 +154,10 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, erpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_fast_bridge_erp_P2SH_chunk() {
         Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
@@ -171,12 +172,10 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_p2sh_erp_P2SH_chunk() {
         Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
@@ -190,12 +189,10 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, p2shErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_fast_bridge_p2sh_erp_P2SH_chunk() {
         Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
@@ -210,25 +207,19 @@ public class RedeemScriptParserFactoryTest {
         );
 
         Script inputScript = spk.createEmptyInputScript(null, fastBridgeP2shErpRedeemScript);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(inputScript.getChunks());
-
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(inputScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_custom_redeem_script_no_multiSig() {
         Script redeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultRedeemScriptKeys);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
-
-        Assert.assertEquals(NO_MULTISIG_TYPE, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(redeemScript.getChunks());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void create_RedeemScriptParser_object_from_custom_redeem_script_insufficient_chunks() {
         Script redeemScript = new Script(new byte[2]);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
-
-        Assert.assertEquals(NO_MULTISIG_TYPE, parser.getMultiSigType());
+        RedeemScriptParserFactory.get(redeemScript.getChunks());
     }
 
     @Test
@@ -241,28 +232,24 @@ public class RedeemScriptParserFactoryTest {
         Assert.assertEquals(NO_MULTISIG_TYPE, parser.getMultiSigType());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void createRedeemScriptParser_whenPassingStandardScriptSig_shouldReturnStandardRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
 
         Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
         Script scriptSig = p2SHOutputScript.createEmptyInputScript(null, redeemScript);
 
-        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(
+        RedeemScriptParserFactory.get(
             scriptSig.getChunks());
-        Assert.assertTrue(redeemScriptParser instanceof StandardRedeemScriptParser);
-        Assert.assertEquals(STANDARD_MULTISIG, redeemScriptParser.getMultiSigType());
     }
 
-    @Test
+    @Test(expected = ScriptException.class)
     public void createRedeemScriptParser_whenP2shOutput_shouldReturnNonStandardErpRedeemScriptParserHardcoded() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
 
         Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
 
-        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(
+        RedeemScriptParserFactory.get(
             p2SHOutputScript.getChunks());
-        Assert.assertTrue(redeemScriptParser instanceof NonStandardErpRedeemScriptParserHardcoded);
-        Assert.assertEquals(NO_MULTISIG_TYPE, redeemScriptParser.getMultiSigType());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptParserFactoryTest.java
@@ -31,46 +31,78 @@ public class RedeemScriptParserFactoryTest {
     }
 
     @Test(expected = ScriptException.class)
-    public void get_whenMalformedMultiSig_shouldFail() {
-        Script redeemScript = new Script(new byte[2]);
-        RedeemScriptParserFactory.get(redeemScript.getChunks());
+    public void get_whenEmptyScript_shouldThrowScriptException() {
+        Script emptyScript = new Script(new byte[0]);
+        RedeemScriptParserFactory.get(emptyScript.getChunks());
+    }
+
+    @Test(expected = ScriptException.class)
+    public void get_whenMalFormedRedeemScript_shouldThrowScriptException() {
+        Script malFormeScript = RedeemScriptUtils.createCustomRedeemScript(defaultRedeemScriptKeys);
+        RedeemScriptParserFactory.get(malFormeScript.getChunks());
+    }
+
+    @Test(expected = ScriptException.class)
+    public void get_whenScriptSig_shouldThrowScriptException() {
+        byte[] flyoverDerivationHash = Sha256Hash.of(new byte[]{1}).getBytes();
+        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
+            flyoverDerivationHash,
+            defaultRedeemScriptKeys
+        );
+
+        Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(
+            2,
+            Arrays.asList(ecKey1, ecKey2, ecKey3)
+        );
+
+        Script scriptSig = p2SHOutputScript.createEmptyInputScript(null, fastBridgeRedeemScript);
+        RedeemScriptParserFactory.get(scriptSig.getChunks());
+    }
+
+    @Test(expected = ScriptException.class)
+    public void get_whenP2shOutputScript_shouldThrowScriptException() {
+        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
+
+        Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+
+        RedeemScriptParserFactory.get(p2SHOutputScript.getChunks());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_fast_bridge_multiSig_chunk() {
+    public void get_whenFlyoverStandardRedeemScript_shouldReturnRedeemScriptParser() {
         byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
         Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
             data,
             defaultRedeemScriptKeys
         );
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(fastBridgeRedeemScript.getChunks());
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, parser.getMultiSigType());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(fastBridgeRedeemScript.getChunks());
+        Assert.assertEquals(MultiSigType.FAST_BRIDGE_MULTISIG, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_standard_multiSig_chunk() {
+    public void get_whenStandardRedeemScript_shouldReturnRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        Assert.assertEquals(STANDARD_MULTISIG, parser.getMultiSigType());
+        Assert.assertEquals(STANDARD_MULTISIG, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_erp_multiSig_chunk() {
+    public void get_whenErpRedeemScript_shouldReturnRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
         );
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        Assert.assertEquals(MultiSigType.ERP_FED, parser.getMultiSigType());
+        Assert.assertEquals(MultiSigType.ERP_FED, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_erp_fast_bridge_multiSig_chunk() {
+    public void get_whenFlyoverErpRedeemScript_shouldReturnRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -78,26 +110,26 @@ public class RedeemScriptParserFactoryTest {
             Sha256Hash.of(new byte[]{1}).getBytes()
         );
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, parser.getMultiSigType());
+        Assert.assertEquals(MultiSigType.FAST_BRIDGE_ERP_FED, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_p2sh_erp_multiSig_chunk() {
+    public void get_whenP2shErpRedeemScript_shouldReturnRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
             500L
         );
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        Assert.assertEquals(MultiSigType.P2SH_ERP_FED, parser.getMultiSigType());
+        Assert.assertEquals(MultiSigType.P2SH_ERP_FED, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_fast_bridge_p2sh_erp_multiSig_chunk() {
+    public void get_whenFlyoverP2shErpRedeemScript_shouldReturnRedeemScriptParser() {
         Script redeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -105,151 +137,18 @@ public class RedeemScriptParserFactoryTest {
             Sha256Hash.of(new byte[]{1}).getBytes()
         );
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, parser.getMultiSigType());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_fast_bridge_P2SH_chunk() {
-        byte[] data = Sha256Hash.of(new byte[]{1}).getBytes();
-        Script fastBridgeRedeemScript = RedeemScriptUtils.createFastBridgeRedeemScript(
-            data,
-            defaultRedeemScriptKeys
-        );
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, fastBridgeRedeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_standard_P2SH_chunk() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, redeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_erp_P2SH_chunk() {
-        Script erpRedeemScript = RedeemScriptUtils.createErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L
-        );
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, erpRedeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_fast_bridge_erp_P2SH_chunk() {
-        Script fastBridgeErpRedeemScript = RedeemScriptUtils.createFastBridgeErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L,
-            Sha256Hash.of(new byte[]{1}).getBytes()
-        );
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, fastBridgeErpRedeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_p2sh_erp_P2SH_chunk() {
-        Script p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L
-        );
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, p2shErpRedeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_fast_bridge_p2sh_erp_P2SH_chunk() {
-        Script fastBridgeP2shErpRedeemScript = RedeemScriptUtils.createFastBridgeP2shErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            500L,
-            Sha256Hash.of(new byte[]{1}).getBytes()
-        );
-
-        Script spk = ScriptBuilder.createP2SHOutputScript(
-            2,
-            Arrays.asList(ecKey1, ecKey2, ecKey3)
-        );
-
-        Script inputScript = spk.createEmptyInputScript(null, fastBridgeP2shErpRedeemScript);
-        RedeemScriptParserFactory.get(inputScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_custom_redeem_script_no_multiSig() {
-        Script redeemScript = RedeemScriptUtils.createCustomRedeemScript(defaultRedeemScriptKeys);
-        RedeemScriptParserFactory.get(redeemScript.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void create_RedeemScriptParser_object_from_custom_redeem_script_insufficient_chunks() {
-        Script redeemScript = new Script(new byte[2]);
-        RedeemScriptParserFactory.get(redeemScript.getChunks());
+        Assert.assertEquals(MultiSigType.FAST_BRIDGE_P2SH_ERP_FED, redeemScriptParser.getMultiSigType());
     }
 
     @Test
-    public void create_RedeemScriptParser_object_from_hardcoded_testnet_redeem_script() {
+    public void get_whenHardcodedTestnetRedeemScript_shouldReturnHardcodeTestnetParser() {
         final byte[] erpTestnetRedeemScriptSerialized = Utils.HEX.decode("6453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f42102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a0921039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb955670300cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368ae");
         Script erpTestnetRedeemScript = new Script(erpTestnetRedeemScriptSerialized);
 
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(erpTestnetRedeemScript.getChunks());
+        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(erpTestnetRedeemScript.getChunks());
 
-        Assert.assertEquals(NO_MULTISIG_TYPE, parser.getMultiSigType());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void createRedeemScriptParser_whenPassingStandardScriptSig_shouldReturnStandardRedeemScriptParser() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-
-        Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-        Script scriptSig = p2SHOutputScript.createEmptyInputScript(null, redeemScript);
-
-        RedeemScriptParserFactory.get(
-            scriptSig.getChunks());
-    }
-
-    @Test(expected = ScriptException.class)
-    public void createRedeemScriptParser_whenP2shOutput_shouldReturnNonStandardErpRedeemScriptParserHardcoded() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-
-        Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-
-        RedeemScriptParserFactory.get(
-            p2SHOutputScript.getChunks());
+        Assert.assertEquals(NO_MULTISIG_TYPE, redeemScriptParser.getMultiSigType());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ScriptTest.java
@@ -617,8 +617,6 @@ public class ScriptTest {
         BtcECKey signingKey = BtcECKey.fromPrivate(BigInteger.valueOf(800));
 
         assertThrows(ArrayIndexOutOfBoundsException.class, () -> redeemScript.getSigInsertionIndex(hashForSignature, signingKey));
-
-        assertScriptIsNoRedeemScript(redeemScript);
     }
 
     @Test
@@ -632,8 +630,6 @@ public class ScriptTest {
         BtcECKey signingKey = BtcECKey.fromPrivate(BigInteger.valueOf(800));
 
         assertThrows(NullPointerException.class, () -> p2shOutputScript.getSigInsertionIndex(hashForSignature, signingKey));
-
-        assertScriptIsNoRedeemScript(p2shOutputScript);
     }
 
     @Test
@@ -645,7 +641,6 @@ public class ScriptTest {
         BtcECKey signingKey = BtcECKey.fromPrivate(BigInteger.valueOf(800));
 
         assertThrows(NullPointerException.class, () -> erpTestnetRedeemScript.getSigInsertionIndex(hashForSignature, signingKey));
-        assertScriptIsNoRedeemScript(erpTestnetRedeemScript);
     }
 
     @Test
@@ -673,26 +668,14 @@ public class ScriptTest {
         Assert.assertEquals(0, actualSigInsertionIndex);
     }
 
-    private static void assertScriptIsNoRedeemScript(Script redeemScript) {
-        RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(
-            redeemScript.getChunks());
-        Assert.assertTrue(redeemScriptParser instanceof NonStandardErpRedeemScriptParserHardcoded);
-    }
-
-    @Test
-    public void getSigInsertionIndex_whenMalformedRedeemScript_shouldReturnZero() {
+    @Test(expected = ScriptException.class)
+    public void getSigInsertionIndex_whenMalformedRedeemScript_shouldThrowException() {
         Script customRedeemScript = new Script(new byte[2]);
 
         Sha256Hash hashForSignature = Sha256Hash.of(new byte[]{1});
         BtcECKey signingKey = BtcECKey.fromPrivate(BigInteger.valueOf(800));
 
-        int sigInsertionIndex = customRedeemScript.getSigInsertionIndex(hashForSignature, signingKey);
-        // This hardcode redeemScript is identified as NoRedeemScriptParser, and is using its findKeyInRedeem implementation
-        // which is returning -1 as default value. This means that the signature insertion index will always be
-        // 0 which is the initial value set when getting the signature insertion index
-        Assert.assertEquals(0, sigInsertionIndex);
-
-        assertScriptIsNoRedeemScript(customRedeemScript);
+        customRedeemScript.getSigInsertionIndex(hashForSignature, signingKey);
     }
 
     @Test
@@ -713,8 +696,6 @@ public class ScriptTest {
         // 0 which is the initial value set when getting the signature insertion index
         int sigInsertionIndex = customRedeemScript.getSigInsertionIndex(hashForSignature, signingKey);
         Assert.assertEquals(0, sigInsertionIndex);
-
-        assertScriptIsNoRedeemScript(customRedeemScript);
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
@@ -3,15 +3,11 @@ package co.rsk.bitcoinj.script;
 import static org.junit.Assert.assertEquals;
 
 import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.crypto.TransactionSignature;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
@@ -130,13 +126,7 @@ public class StandardRedeemScriptParserTest {
         parser.getPubKeys();
     }
 
-    @Test
-    public void getM_from_no_multiSig() {
-        Script redeemScript = new Script(new byte[2]);
-        RedeemScriptParser parser = RedeemScriptParserFactory.get(redeemScript.getChunks());
 
-        assertEquals(-1, parser.getM());
-    }
 
     @Test
     public void getM_from_multiSig_fast_bridge_redeem_script() {


### PR DESCRIPTION
Update RedeemScriptParserFactory class to only handle RedeemScript type and throw a ScriptException for no redeem script type.

## Motivation and Context

Aiming to decouple and make RedeemScriptParserFactory with a clear and specific responsibility as its name implies, we should stop treating ScriptSig and P2sh as RedeemScript when parsing. Therefore, we propose to update this logic only to parse redeemScript type of scripts.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
