### PR TITLE
Move tests to flyover test class and improve StandardRedeemScriptParser tests

### DIFF
--- a/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FastBridgeRedeemScriptParserTest.java
@@ -1,6 +1,5 @@
 package co.rsk.bitcoinj.script;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import co.rsk.bitcoinj.core.BtcECKey;


### PR DESCRIPTION
## Motivation and Context

There were many tests related to flyover redeem script parser wronly placed in StandardRedeemScriptParser test class. Therefore, those tests were moved tests out of StandardRedeemScriptParserTest class. 

Also, we reorganized and added new tests for StandardRedeemScriptParser.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
