### PR TITLE
Get rid of isStandardMultiSig from StandardRedeemScriptParser

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -37,7 +37,7 @@ public class RedeemScriptParserFactory {
                 redeemScriptChunks
             );
         }
-        if (StandardRedeemScriptParser.isStandardMultiSig(redeemScriptChunks)) {
+        if (RedeemScriptValidator.hasStandardRedeemScriptStructure(redeemScriptChunks)) {
             logger.debug("[get] Return StandardRedeemScriptParser");
             return new StandardRedeemScriptParser(
                 redeemScriptChunks

--- a/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
@@ -81,8 +81,4 @@ public class StandardRedeemScriptParser implements RedeemScriptParser {
     public List<ScriptChunk> extractStandardRedeemScriptChunks() {
         return redeemScriptChunks;
     }
-
-    public static boolean isStandardMultiSig(List<ScriptChunk> chunks) {
-        return RedeemScriptValidator.hasStandardRedeemScriptStructure(chunks);
-    }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/StandardRedeemScriptParserTest.java
@@ -3,7 +3,6 @@ package co.rsk.bitcoinj.script;
 import static org.junit.Assert.assertEquals;
 
 import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import java.math.BigInteger;
@@ -20,7 +19,6 @@ public class StandardRedeemScriptParserTest {
     private final BtcECKey ecKey1 = BtcECKey.fromPrivate(BigInteger.valueOf(100));
     private final BtcECKey ecKey2 = BtcECKey.fromPrivate(BigInteger.valueOf(200));
     private final BtcECKey ecKey3 = BtcECKey.fromPrivate(BigInteger.valueOf(300));
-    private final NetworkParameters networkParameters = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
     @Before
     public void setUp() {


### PR DESCRIPTION
## Description
The `StandardRedeemScriptParser#isStandardMultiSig` method is redundant. This validation should be used through the `RedeemScriptValidator#hasStandardRedeemScriptStructure` since that’s the right place to have the redeem script structures validations.

Therefore, we propose to eliminate the redundant `isStandardMultiSig` method from `StandardRedeemScriptParser`. By doing so, we can use the `hasStandardRedeemScriptStructure` method directly instead.

## Motivation and Context
This relates to the Refactors to add `SegwitRedeemScriptParser`.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: