### PR TITLE
Get rid of isNonStandardErpFed from NonStandardErpRedeemScriptParser

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParser.java
@@ -70,8 +70,4 @@ public class NonStandardErpRedeemScriptParser implements RedeemScriptParser {
 
         return chunksForRedeem;
     }
-
-    public static boolean isNonStandardErpFed(List<ScriptChunk> chunks) {
-        return RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(chunks);
-    }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParserFactory.java
@@ -27,7 +27,7 @@ public class RedeemScriptParserFactory {
         if (redeemScriptChunks.size() < 4) {
             // A multisig redeem script must have at least 4 redeemScriptChunks (OP_N [PUB1 ...] OP_N CHECK_MULTISIG)
             final String errorMessage = "The provided redeem script has less than 4 redeemScriptChunks.";
-            logger.trace(String.format("[get] %s", errorMessage));
+            logger.trace("[get] {}", errorMessage);
             throw new ScriptException(errorMessage);
         }
 
@@ -55,7 +55,7 @@ public class RedeemScriptParserFactory {
                 redeemScriptChunks
             );
         }
-        if (NonStandardErpRedeemScriptParser.isNonStandardErpFed(redeemScriptChunks)) {
+        if (RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(redeemScriptChunks)) {
             logger.debug("[get] Return NonStandardErpRedeemScriptParser");
             return new NonStandardErpRedeemScriptParser(
                 redeemScriptChunks

--- a/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
@@ -60,7 +60,7 @@ public class NonStandardErpRedeemScriptParserTest {
             200L
         );
 
-        Assert.assertTrue(NonStandardErpRedeemScriptParser.isNonStandardErpFed(erpRedeemScript.getChunks()));
+        Assert.assertTrue(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(erpRedeemScript.getChunks()));
     }
 
     @Test
@@ -69,7 +69,7 @@ public class NonStandardErpRedeemScriptParserTest {
             defaultRedeemScriptKeys
         );
 
-        Assert.assertFalse(NonStandardErpRedeemScriptParser.isNonStandardErpFed(customRedeemScript.getChunks()));
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(customRedeemScript.getChunks()));
     }
 
     @Test

--- a/src/test/java/co/rsk/bitcoinj/script/P2ShErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2ShErpRedeemScriptParserTest.java
@@ -78,7 +78,7 @@ public class P2ShErpRedeemScriptParserTest {
             200L
         );
 
-        Assert.assertFalse(NonStandardErpRedeemScriptParser.isNonStandardErpFed(erpRedeemScript.getChunks()));
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(erpRedeemScript.getChunks()));
     }
 
     @Test


### PR DESCRIPTION
## Description
The `NonStandardErpRedeemScriptParser#isNonStandardErpFed` is redundant. This validation should be used through the `RedeemScriptValidator#hasNonStandardErpRedeemScriptStructure` since that’s the right place to have the redeem script structures validations.

Therefore, we propose eliminating the redundant `isNonStandardErpFed` method from the `NonStandardErpRedeemScriptParser.` By doing so, we can use the `hasNonStandardErpRedeemScriptStructure` method directly instead. 

## Motivation and Context
This relates to the Refactors to add `SegwitRedeemScriptParser.`

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
