### PR TITLE
Add has erp format method

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParser.java
@@ -12,7 +12,7 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
     private static final Logger logger = LoggerFactory.getLogger(FlyoverRedeemScriptParser.class);
     private final RedeemScriptParser internalRedeemScriptParser;
 
-    public FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
+    FlyoverRedeemScriptParser(List<ScriptChunk> redeemScriptChunks) {
         List<ScriptChunk> internalRedeemScriptChunks = extractInternalRedeemScriptChunks(redeemScriptChunks);
         this.internalRedeemScriptParser = RedeemScriptParserFactory.get(internalRedeemScriptChunks);
     }
@@ -55,5 +55,10 @@ public class FlyoverRedeemScriptParser implements RedeemScriptParser {
         }
 
         return chunks.subList(2, chunks.size());
+    }
+
+    @Override
+    public boolean hasErpFormat() {
+        return internalRedeemScriptParser.hasErpFormat();
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParser.java
@@ -13,7 +13,7 @@ public class NonStandardErpRedeemScriptParser implements RedeemScriptParser {
 
     private final RedeemScriptParser defaultRedeemScriptParser;
 
-    public NonStandardErpRedeemScriptParser(
+    NonStandardErpRedeemScriptParser(
         List<ScriptChunk> redeemScriptChunks
     ) {
         List<ScriptChunk> defaultRedeemScriptChunks = extractDefaultRedeemScriptChunks(redeemScriptChunks);
@@ -69,5 +69,10 @@ public class NonStandardErpRedeemScriptParser implements RedeemScriptParser {
         }
 
         return chunksForRedeem;
+    }
+
+    @Override
+    public boolean hasErpFormat() {
+        return true;
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcoded.java
+++ b/src/main/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcoded.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 public class NonStandardErpRedeemScriptParserHardcoded implements RedeemScriptParser {
 
+    NonStandardErpRedeemScriptParserHardcoded() { }
+
     @Override
     public MultiSigType getMultiSigType() {
         return MultiSigType.NO_MULTISIG_TYPE;
@@ -35,5 +37,12 @@ public class NonStandardErpRedeemScriptParserHardcoded implements RedeemScriptPa
     @Override
     public List<ScriptChunk> extractStandardRedeemScriptChunks() {
         throw new ScriptException("Only usable for multisig scripts.");
+    }
+
+    @Override
+    public boolean hasErpFormat() {
+        // This parser is exclusive for an invalid redeem script.
+        // Therefore, it is not considered as a valid erp format.
+        return false;
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/P2shErpRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/P2shErpRedeemScriptParser.java
@@ -15,7 +15,7 @@ public class P2shErpRedeemScriptParser implements RedeemScriptParser {
 
     private final RedeemScriptParser defaultRedeemScriptParser;
 
-    public P2shErpRedeemScriptParser(
+    P2shErpRedeemScriptParser(
         List<ScriptChunk> redeemScriptChunks
     ) {
         List<ScriptChunk> defaultRedeemScriptChunks = extractDefaultRedeemScriptChunks(redeemScriptChunks);
@@ -69,5 +69,10 @@ public class P2shErpRedeemScriptParser implements RedeemScriptParser {
         }
 
         return chunksForRedeem;
+    }
+
+    @Override
+    public boolean hasErpFormat() {
+        return true;
     }
 }

--- a/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/RedeemScriptParser.java
@@ -25,4 +25,6 @@ public interface RedeemScriptParser {
     int findSigInRedeem(byte[] signatureBytes, Sha256Hash hash);
 
     List<ScriptChunk> extractStandardRedeemScriptChunks();
+
+    boolean hasErpFormat();
 }

--- a/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
+++ b/src/main/java/co/rsk/bitcoinj/script/StandardRedeemScriptParser.java
@@ -18,7 +18,7 @@ public class StandardRedeemScriptParser implements RedeemScriptParser {
     // Standard redeem script
     protected List<ScriptChunk> redeemScriptChunks;
 
-    public StandardRedeemScriptParser(
+    StandardRedeemScriptParser(
         List<ScriptChunk> redeemScriptChunks
     ) {
         this.multiSigType = MultiSigType.STANDARD_MULTISIG;
@@ -80,5 +80,10 @@ public class StandardRedeemScriptParser implements RedeemScriptParser {
     @Override
     public List<ScriptChunk> extractStandardRedeemScriptChunks() {
         return redeemScriptChunks;
+    }
+
+    @Override
+    public boolean hasErpFormat() {
+        return false;
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -311,7 +311,7 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     private void assertHasErpFormat(Script flyoverRedeemScript) {
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = (FlyoverRedeemScriptParser) RedeemScriptParserFactory.get(flyoverRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverRedeemScript.getChunks());
         assertTrue(flyoverRedeemScriptParser.hasErpFormat());
     }
 

--- a/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/FlyoverRedeemScriptParserTest.java
@@ -2,7 +2,9 @@ package co.rsk.bitcoinj.script;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcECKey;
@@ -11,6 +13,7 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.core.VerificationException;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.MainNetParams;
@@ -25,10 +28,16 @@ public class FlyoverRedeemScriptParserTest {
     private final List<BtcECKey> keys = RedeemScriptUtils.getDefaultRedeemScriptKeys();
     private final List<BtcECKey> emergencyKeys = RedeemScriptUtils.getEmergencyRedeemScriptKeys();
     private final Sha256Hash flyoverDerivationHash = Sha256Hash.of(new byte[]{1});
+
     private Script standardRedeemScript;
     private Script flyoverStandardRedeemScript;
-    private Script erpRedeemScript;
-    private Script flyoverErpRedeemScript;
+
+    private final byte[] nonStandardErpRedeemScriptSerialized = Utils.HEX.decode("6453210208f40073a9e43b3e9103acec79767a6de9b0409749884e989960fee578012fce210225e892391625854128c5c4ea4340de0c2a70570f33db53426fc9c746597a03f42102afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da210344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a0921039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb955670300cd50b27552210216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3210275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f1421034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f5368ae");
+    private Script flyoverNonStandardErpRedeemScriptParserHardcoded;
+
+    private Script nonStandardErpRedeemScript;
+    private Script flyoverNonStandardErpRedeemScript;
+
     private Script p2shErpRedeemScript;
     private Script flyoverP2shErpRedeemScript;
 
@@ -39,8 +48,14 @@ public class FlyoverRedeemScriptParserTest {
         flyoverStandardRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(
             flyoverDerivationHash.getBytes(), standardRedeemScript);
 
-        erpRedeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(keys, emergencyKeys, CSV_VALUE);
-        flyoverErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(flyoverDerivationHash.getBytes(), erpRedeemScript);
+        Script nonStandardErpRedeemScriptParserHardcoded = new Script(
+            nonStandardErpRedeemScriptSerialized);
+        flyoverNonStandardErpRedeemScriptParserHardcoded = RedeemScriptUtils.createFlyoverRedeemScript(flyoverDerivationHash.getBytes(),
+            nonStandardErpRedeemScriptParserHardcoded);
+
+        nonStandardErpRedeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(keys, emergencyKeys, CSV_VALUE);
+        flyoverNonStandardErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(flyoverDerivationHash.getBytes(),
+            nonStandardErpRedeemScript);
 
         p2shErpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(keys, emergencyKeys, CSV_VALUE);
         flyoverP2shErpRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(
@@ -53,8 +68,8 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void getMultiSigType_whenIsErpRedeemScript_shouldReturnFlyoverMultiSigType() {
-        assertIsFlyoverMultiSigType(flyoverErpRedeemScript);
+    public void getMultiSigType_whenIsNonStandardErpRedeemScriptErpRedeemScript_shouldReturnFlyoverMultiSigType() {
+        assertIsFlyoverMultiSigType(flyoverNonStandardErpRedeemScript);
     }
 
     @Test
@@ -79,8 +94,8 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void getM_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnMValue() {
-        assertGetMValue(flyoverErpRedeemScript);
+    public void getM_whenFlyoverRedeemScriptContainsNonStandardErpRedeemScript_shouldReturnMValue() {
+        assertGetMValue(flyoverNonStandardErpRedeemScript);
     }
 
     @Test
@@ -106,8 +121,8 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void findKeyInRedeem_whenKeyIsInErpRedeemScript_shouldReturnKeyIndexPosition() {
-        assertKeyInRedeem(flyoverErpRedeemScript);
+    public void findKeyInRedeem_whenKeyIsInNonStandardErpRedeemScript_shouldReturnKeyIndexPosition() {
+        assertKeyInRedeem(flyoverNonStandardErpRedeemScript);
     }
 
     @Test
@@ -131,7 +146,7 @@ public class FlyoverRedeemScriptParserTest {
 
     @Test(expected = IllegalStateException.class)
     public void findKeyInRedeem_whenKeyIsNotInNonStandardErpRedeemScript_shouldThrowIllegalStateException() {
-        assertThrowsIllegalStateException(flyoverErpRedeemScript);
+        assertThrowsIllegalStateException(flyoverNonStandardErpRedeemScript);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -154,8 +169,8 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void getPubKeys_whenFlyoverRedeemScriptContainsErpRedeemScript_shouldReturnPubKeys() {
-        assertPubKeys(flyoverErpRedeemScript);
+    public void getPubKeys_whenFlyoverRedeemScriptContainsNonStandardErpRedeemScript_shouldReturnPubKeys() {
+        assertPubKeys(flyoverNonStandardErpRedeemScript);
     }
 
     @Test
@@ -185,8 +200,8 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void findSigInRedeem_whenSignatureIsInErpRedeemScript_shouldReturnSignatureIndexPosition() {
-        assertSigInRedeem(flyoverErpRedeemScript);
+    public void findSigInRedeem_whenSignatureIsInNonStandardErpRedeemScript_shouldReturnSignatureIndexPosition() {
+        assertSigInRedeem(flyoverNonStandardErpRedeemScript);
     }
 
     @Test
@@ -246,11 +261,13 @@ public class FlyoverRedeemScriptParserTest {
     }
 
     @Test
-    public void extractStandardRedeemScriptChunks_whenIsErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
+    public void extractStandardRedeemScriptChunks_whenIsNonStandardErpRedeemScript_shouldReturnStandardRedeemScriptChunks() {
         // Arrange
-        NonStandardErpRedeemScriptParser nonStandardErpRedeemScriptParser = new NonStandardErpRedeemScriptParser(erpRedeemScript.getChunks());
+        NonStandardErpRedeemScriptParser nonStandardErpRedeemScriptParser = new NonStandardErpRedeemScriptParser(
+            nonStandardErpRedeemScript.getChunks());
         List<ScriptChunk> expectedStandardRedeemScriptChunks = nonStandardErpRedeemScriptParser.extractStandardRedeemScriptChunks();
-        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(flyoverErpRedeemScript.getChunks());
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = new FlyoverRedeemScriptParser(
+            flyoverNonStandardErpRedeemScript.getChunks());
 
         // Act
         List<ScriptChunk> actualRedeemScriptChunks = flyoverRedeemScriptParser.extractStandardRedeemScriptChunks();
@@ -271,6 +288,36 @@ public class FlyoverRedeemScriptParserTest {
 
         // Assert
         assertEquals(expectedStandardRedeemScriptChunks, actualRedeemScriptChunks);
+    }
+
+    @Test
+    public void hasErpFormat_whenFlyoverStandardRedeemScript_shouldReturnFalse() {
+        assertHasNotErpFormat(flyoverStandardRedeemScript);
+    }
+
+    @Test
+    public void hasErpFormat_whenFlyoverNonStandardErpRedeemScriptHardcoded_shouldReturnFalse() {
+        assertHasNotErpFormat(flyoverNonStandardErpRedeemScriptParserHardcoded);
+    }
+
+    @Test
+    public void hasErpFormat_whenFlyoverNonStandardErpRedeemScript_shouldReturnTrue() {
+        assertHasErpFormat(flyoverNonStandardErpRedeemScript);
+    }
+
+    @Test
+    public void hasErpFormat_whenFlyoverP2shRedeemScript_shouldReturnTrue() {
+        assertHasErpFormat(flyoverP2shErpRedeemScript);
+    }
+
+    private void assertHasErpFormat(Script flyoverRedeemScript) {
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = (FlyoverRedeemScriptParser) RedeemScriptParserFactory.get(flyoverRedeemScript.getChunks());
+        assertTrue(flyoverRedeemScriptParser.hasErpFormat());
+    }
+
+    private void assertHasNotErpFormat(Script flyoverRedeemScript) {
+        FlyoverRedeemScriptParser flyoverRedeemScriptParser = (FlyoverRedeemScriptParser) RedeemScriptParserFactory.get(flyoverRedeemScript.getChunks());
+        assertFalse(flyoverRedeemScriptParser.hasErpFormat());
     }
 
     @Test(expected = VerificationException.class)

--- a/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcodedTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserHardcodedTest.java
@@ -1,6 +1,7 @@
 package co.rsk.bitcoinj.script;
 
 import co.rsk.bitcoinj.core.ScriptException;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class NonStandardErpRedeemScriptParserHardcodedTest {
@@ -11,5 +12,10 @@ public class NonStandardErpRedeemScriptParserHardcodedTest {
     public void extractStandardRedeemScriptChunks_shouldThrowScriptException() {
         // Act
         nonStandardErpRedeemScriptParserHardcoded.extractStandardRedeemScriptChunks();
+    }
+
+    @Test
+    public void hasErpFormat_shouldReturnFalse() {
+        Assert.assertFalse(nonStandardErpRedeemScriptParserHardcoded.hasErpFormat());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
@@ -53,26 +53,6 @@ public class NonStandardErpRedeemScriptParserTest {
     }
 
     @Test
-    public void isNonStandardErpFed_whenNonStandardErpRedeemScript_shouldReturnTrue() {
-        Script erpRedeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            200L
-        );
-
-        Assert.assertTrue(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(erpRedeemScript.getChunks()));
-    }
-
-    @Test
-    public void isNonStandardErpFed_whenCustomRedeemScript_shouldReturnFalse() {
-        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
-            defaultRedeemScriptKeys
-        );
-
-        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(customRedeemScript.getChunks()));
-    }
-
-    @Test
     public void getMultiSigType_shouldReturnNonStandardErpFedType() {
         Assert.assertEquals(MultiSigType.NON_STANDARD_ERP_FED, nonStandardErpRedeemScriptParser.getMultiSigType());
     }

--- a/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/NonStandardErpRedeemScriptParserTest.java
@@ -113,4 +113,9 @@ public class NonStandardErpRedeemScriptParserTest {
         ).getChunks();
         Assert.assertEquals(expectedStandardRedeemScriptChunks, nonStandardErpRedeemScriptParser.extractStandardRedeemScriptChunks());
     }
+
+    @Test
+    public void hasErpFormat_shouldReturnTrue() {
+        Assert.assertTrue(nonStandardErpRedeemScriptParser.hasErpFormat());
+    }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/P2ShErpRedeemScriptParserTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/P2ShErpRedeemScriptParserTest.java
@@ -60,17 +60,6 @@ public class P2ShErpRedeemScriptParserTest {
     }
 
     @Test
-    public void isErpFed_falseWithP2shErpRedeemScript() {
-        Script erpRedeemScript = RedeemScriptUtils.createP2shErpRedeemScript(
-            defaultRedeemScriptKeys,
-            emergencyRedeemScriptKeys,
-            200L
-        );
-
-        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(erpRedeemScript.getChunks()));
-    }
-
-    @Test
     public void getMultiSigType_shouldReturnP2shErpFedType() {
         Assert.assertEquals(MultiSigType.P2SH_ERP_FED, p2ShErpRedeemScriptParser.getMultiSigType());
     }
@@ -110,5 +99,10 @@ public class P2ShErpRedeemScriptParserTest {
             defaultRedeemScriptKeys
         ).getChunks();
         Assert.assertEquals(expectedStandardRedeemScriptChunks, p2ShErpRedeemScriptParser.extractStandardRedeemScriptChunks());
+    }
+
+    @Test
+    public void hasErpFormat_shouldReturnTrue() {
+        Assert.assertTrue(p2ShErpRedeemScriptParser.hasErpFormat());
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/RedeemScriptValidatorTest.java
@@ -165,25 +165,31 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasNonStandardErpRedeemScriptStructure_standard_redeem_script() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(redeemScript.getChunks()));
-    }
-
-    @Test
-    public void hasNonStandardErpRedeemScriptStructure_whenFlyoverRedeemScript_shouldReturnFalse() {
-        Script redeemScript = RedeemScriptUtils.createStandardRedeemScript(defaultRedeemScriptKeys);
-
-        Script flyoverRedeemScript = RedeemScriptUtils.createFlyoverRedeemScript(
-            FLYOVER_DERIVATION_HASH.getBytes(),
-            redeemScript
+    public void hasNonStandardErpRedeemScriptStructure_whenCustomRedeemScript_shouldReturnFalse() {
+        Script customRedeemScript = RedeemScriptUtils.createCustomRedeemScript(
+            defaultRedeemScriptKeys
         );
 
-        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(flyoverRedeemScript.getChunks()));
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(customRedeemScript.getChunks()));
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptOneByteCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenStandardRedeemScript_shouldReturnFalse() {
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(standardRedeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasNonStandardErpRedeemScriptStructure_whenP2shErpRedeemScript_shouldReturnFalse() {
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(p2shErpRedeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasNonStandardErpRedeemScriptStructure_whenFlyoverStandardRedeemScript_shouldReturnFalse() {
+        Assert.assertFalse(RedeemScriptValidator.hasNonStandardErpRedeemScriptStructure(flyoverStandardRedeemScript.getChunks()));
+    }
+
+    @Test
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptOneByteCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -194,7 +200,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptTwoBytesCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptTwoBytesCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -205,7 +211,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptTwoBytesIncludingSignCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptTwoBytesIncludingSignCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -216,7 +222,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptThreeBytesCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptThreeBytesCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -227,7 +233,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptThreeBytesIncludingSignCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptThreeBytesIncludingSignCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -238,7 +244,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptFourBytesCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptFourBytesCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -249,7 +255,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptFourBytesIncludingSignCsvValue_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenNonStandardErpFedRedeemScriptFourBytesIncludingSignCsvValue_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,
@@ -260,7 +266,7 @@ public class RedeemScriptValidatorTest {
     }
 
     @Test
-    public void hasErpRedeemScriptStructure_whenFlyoverNonStandardErpRedeemScriptRemovingPrefix_shouldReturnTrue() {
+    public void hasNonStandardErpRedeemScriptStructure_whenFlyoverNonStandardErpRedeemScriptRemovingPrefix_shouldReturnTrue() {
         Script redeemScript = RedeemScriptUtils.createNonStandardErpRedeemScript(
             defaultRedeemScriptKeys,
             emergencyRedeemScriptKeys,


### PR DESCRIPTION
## Description

- Make the constructor private for all the redeem script parser impls
- Add hasErpFormat method to RedeemScriptParser interface
- Implement hasErpFormat in each of the implementation
- Rearrange StandardRedeemScriptParserTest
- Rearrange FlyoverRedeemScriptParserTest
- Move tests out of the NonStandardErpRedeemScriptParserTest since they belong to RedeemScriptValidatorTest
- Rename tests in RedeemScriptValidatorTest to use the new method name hasNonStandardErpRedeemScriptStructure as prefix
- Add tests for hasErpFormat

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
