### PR TITLE
Refactor isSentToMultiSig implementation

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/Script.java
+++ b/src/main/java/co/rsk/bitcoinj/script/Script.java
@@ -32,7 +32,6 @@ import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.UnsafeByteArrayOutputStream;
 import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
-import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
@@ -682,6 +681,14 @@ public class Script {
      */
     public boolean isSentToMultiSig() {
         try {
+            /*
+             * Since NonStandardErpRedeemScriptParserHardcoded shouldn't
+             * be considered a multisig, we cannot rely only on being able to parse the script.
+             * This is why we also check if M is greater than 0, so in case this script is a NonStandardErpRedeemScriptParserHardcoded
+             * it will return -1. Therefore, the condition will be false.
+             *
+             * Any no parseable script will fail when parsing and return false.
+            */
             return this.getRedeemScriptParser().getM() > 0;
         } catch (ScriptException e) {
             return false;

--- a/src/main/java/co/rsk/bitcoinj/script/Script.java
+++ b/src/main/java/co/rsk/bitcoinj/script/Script.java
@@ -682,25 +682,10 @@ public class Script {
      */
     public boolean isSentToMultiSig() {
         try {
-            MultiSigType multiSigType = this.getRedeemScriptParser().getMultiSigType();
-
-            if (MultiSigType.FLYOVER == multiSigType) {
-                multiSigType = getMultiSigTypeFromInternalRedeemScript();
-            }
-            return multiSigType != MultiSigType.NO_MULTISIG_TYPE;
+            return this.getRedeemScriptParser().getM() > 0;
         } catch (ScriptException e) {
             return false;
         }
-    }
-
-    private MultiSigType getMultiSigTypeFromInternalRedeemScript() {
-        MultiSigType multiSigType;
-        List<ScriptChunk> internalRedeemScriptChunks = this.getChunks()
-            .subList(2, chunks.size());
-        RedeemScriptParser internalRedeemScriptParser = RedeemScriptParserFactory.get(
-            internalRedeemScriptChunks);
-        multiSigType = internalRedeemScriptParser.getMultiSigType();
-        return multiSigType;
     }
 
     public boolean isSentToCLTVPaymentChannel() {


### PR DESCRIPTION
## Description

Refactor isSentToMultiSig implementation to not rely on MultisigType enum. Now it uses getM method to determine if it is a multisig or not.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
