### PR TITLE
Remove unused private field form Script class

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/Script.java
+++ b/src/main/java/co/rsk/bitcoinj/script/Script.java
@@ -179,13 +179,6 @@ public class Script {
         return Collections.unmodifiableList(chunks);
     }
 
-    private static final ScriptChunk[] STANDARD_TRANSACTION_SCRIPT_CHUNKS = {
-        new ScriptChunk(ScriptOpCodes.OP_DUP, null, 0),
-        new ScriptChunk(ScriptOpCodes.OP_HASH160, null, 1),
-        new ScriptChunk(ScriptOpCodes.OP_EQUALVERIFY, null, 23),
-        new ScriptChunk(ScriptOpCodes.OP_CHECKSIG, null, 24),
-    };
-
     /**
      * <p>To run a script, first we parse it which breaks it up into chunks representing pushes of data or logical
      * opcodes. Then we can run the parsed chunks.</p>


### PR DESCRIPTION
- Remove unused private field form Script class
- Legacy code, this is currently part of [ScriptParser](https://github.com/rsksmart/bitcoinj-thin/blob/wip/fed-scripts-refactors-integration/src/main/java/co/rsk/bitcoinj/script/ScriptParser.java#L14) 