### PR TITLE
Add serializeCompactV2 method to serialize block with 32-byte chainwork

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/core/CheckpointManager.java
+++ b/src/main/java/co/rsk/bitcoinj/core/CheckpointManager.java
@@ -130,7 +130,7 @@ public class CheckpointManager {
             digestInputStream.on(true);
             int numCheckpoints = dis.readInt();
             checkState(numCheckpoints > 0);
-            final int size = StoredBlock.COMPACT_SERIALIZED_SIZE;
+            final int size = StoredBlock.COMPACT_SERIALIZED_SIZE_LEGACY;
             ByteBuffer buffer = ByteBuffer.allocate(size);
             for (int i = 0; i < numCheckpoints; i++) {
                 if (dis.read(buffer.array(), 0, size) < size)
@@ -165,7 +165,7 @@ public class CheckpointManager {
             checkState(numCheckpoints > 0);
             // Hash numCheckpoints in a way compatible to the binary format.
             hasher.putBytes(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(numCheckpoints).array());
-            final int size = StoredBlock.COMPACT_SERIALIZED_SIZE;
+            final int size = StoredBlock.COMPACT_SERIALIZED_SIZE_LEGACY;
             ByteBuffer buffer = ByteBuffer.allocate(size);
             for (int i = 0; i < numCheckpoints; i++) {
                 byte[] bytes = BASE64.decode(reader.readLine());

--- a/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
+++ b/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
@@ -35,8 +35,8 @@ import java.util.Locale;
  */
 public class StoredBlock {
 
-    // A BigInteger representing the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
-    // unsigned bytes to store this value, so developers should use the V2 format.
+    /* A BigInteger representing the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
+     unsigned bytes to store this value, so developers should use the V2 format. */
     private static final int CHAIN_WORK_BYTES_V1 = 12;
     // A BigInteger representing the total amount of work done so far on this chain.
     private static final int CHAIN_WORK_BYTES_V2 = 32;
@@ -44,9 +44,9 @@ public class StoredBlock {
     private static final int HEIGHT_BYTES = 4;
     // Used for padding.
     private static final byte[] EMPTY_BYTES = new byte[CHAIN_WORK_BYTES_V2]; // fit larger format
-    /** Number of bytes serialized by {@link #serializeCompact(ByteBuffer)} */
+    // Number of bytes serialized by {@link #serializeCompact(ByteBuffer)} 
     public static final int COMPACT_SERIALIZED_SIZE = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V1 + HEIGHT_BYTES;
-    /** Number of bytes serialized by {@link #serializeCompactV2(ByteBuffer)} */
+    // Number of bytes serialized by {@link #serializeCompactV2(ByteBuffer)}
     public static final int COMPACT_SERIALIZED_SIZE_V2 = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V2 + HEIGHT_BYTES;
 
     private BtcBlock header;

--- a/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
+++ b/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
@@ -35,11 +35,19 @@ import java.util.Locale;
  */
 public class StoredBlock {
 
-    // A BigInteger representing the total amount of work done so far on this chain. As of May 2011 it takes 8
-    // bytes to represent this field, so 12 bytes should be plenty for now.
-    public static final int CHAIN_WORK_BYTES = 12;
-    public static final byte[] EMPTY_BYTES = new byte[CHAIN_WORK_BYTES];
-    public static final int COMPACT_SERIALIZED_SIZE = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES + 4;  // for height
+    // A BigInteger representing the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
+    // unsigned bytes to store this value, so developers should use the V2 format.
+    private static final int CHAIN_WORK_BYTES_V1 = 12;
+    // A BigInteger representing the total amount of work done so far on this chain.
+    private static final int CHAIN_WORK_BYTES_V2 = 32;
+    // Height is an int.
+    private static final int HEIGHT_BYTES = 4;
+    // Used for padding.
+    private static final byte[] EMPTY_BYTES = new byte[CHAIN_WORK_BYTES_V2]; // fit larger format
+    /** Number of bytes serialized by {@link #serializeCompact(ByteBuffer)} */
+    public static final int COMPACT_SERIALIZED_SIZE = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V1 + HEIGHT_BYTES;
+    /** Number of bytes serialized by {@link #serializeCompactV2(ByteBuffer)} */
+    public static final int COMPACT_SERIALIZED_SIZE_V2 = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V2 + HEIGHT_BYTES;
 
     private BtcBlock header;
     private BigInteger chainWork;
@@ -113,12 +121,37 @@ public class StoredBlock {
         return store.get(getHeader().getPrevBlockHash());
     }
 
-    /** Serializes the stored block to a custom packed format. Used by {@link CheckpointManager}. */
+    /**
+     * Serializes the stored block to a custom packed format. Used internally.
+     * As of June 22, 2024, it takes 12 unsigned bytes to store the chain work value,
+     * so developers should use the V2 format.
+     *
+     * @param buffer buffer to write to
+     */
     public void serializeCompact(ByteBuffer buffer) {
-        byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES);
-        if (chainWorkBytes.length < CHAIN_WORK_BYTES) {
+        byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES_V1);
+        if (chainWorkBytes.length < CHAIN_WORK_BYTES_V1) {
             // Pad to the right size.
-            buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES - chainWorkBytes.length);
+            buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES_V1 - chainWorkBytes.length);
+        }
+        buffer.put(chainWorkBytes);
+        buffer.putInt(getHeight());
+        // Using unsafeBitcoinSerialize here can give us direct access to the same bytes we read off the wire,
+        // avoiding serialization round-trips.
+        byte[] bytes = getHeader().unsafeBitcoinSerialize();
+        buffer.put(bytes, 0, BtcBlock.HEADER_SIZE);  // Trim the trailing 00 byte (zero transactions).
+    }
+
+    /**
+     * Serializes the stored block to a custom packed format. Used internally.
+     *
+     * @param buffer buffer to write to
+     */
+    public void serializeCompactV2(ByteBuffer buffer) {
+        byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES_V2);
+        if (chainWorkBytes.length < CHAIN_WORK_BYTES_V2) {
+            // Pad to the right size.
+            buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES_V2 - chainWorkBytes.length);
         }
         buffer.put(chainWorkBytes);
         buffer.putInt(getHeight());
@@ -130,7 +163,7 @@ public class StoredBlock {
 
     /** De-serializes the stored block from a custom packed format. Used by {@link CheckpointManager}. */
     public static StoredBlock deserializeCompact(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
-        byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES];
+        byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_V1];
         buffer.get(chainWorkBytes);
         BigInteger chainWork = new BigInteger(1, chainWorkBytes);
         int height = buffer.getInt();  // +4 bytes

--- a/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
+++ b/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
@@ -35,18 +35,17 @@ import java.util.Locale;
  */
 public class StoredBlock {
 
-    /* A BigInteger representing the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
+    /* Size in bytes to represent the total amount of work done so far on this chain. As of June 22, 2024, it takes 12
      unsigned bytes to store this value, so developers should use the V2 format. */
     private static final int CHAIN_WORK_BYTES_V1 = 12;
-    // A BigInteger representing the total amount of work done so far on this chain.
+    // Size in bytes to represent the total amount of work done so far on this chain.
     private static final int CHAIN_WORK_BYTES_V2 = 32;
-    // Height is an int.
+    // Size in bytes(int) to represent btc block height
     private static final int HEIGHT_BYTES = 4;
-    // Used for padding.
-    private static final byte[] EMPTY_BYTES = new byte[CHAIN_WORK_BYTES_V2]; // fit larger format
-    // Number of bytes serialized by {@link #serializeCompact(ByteBuffer)} 
+
+    // Size in bytes of serialized block in legacy format by {@link #serializeCompactLegacy(ByteBuffer)}
     public static final int COMPACT_SERIALIZED_SIZE = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V1 + HEIGHT_BYTES;
-    // Number of bytes serialized by {@link #serializeCompactV2(ByteBuffer)}
+    // Size in bytes of serialized block in V2 format by {@link #serializeCompactV2(ByteBuffer)}
     public static final int COMPACT_SERIALIZED_SIZE_V2 = BtcBlock.HEADER_SIZE + CHAIN_WORK_BYTES_V2 + HEIGHT_BYTES;
 
     private BtcBlock header;
@@ -122,18 +121,17 @@ public class StoredBlock {
     }
 
     /**
+     * @deprecated Use {@link #serializeCompactV2(ByteBuffer)} instead.
+     *
      * Serializes the stored block to a custom packed format. Used internally.
      * As of June 22, 2024, it takes 12 unsigned bytes to store the chain work value,
      * so developers should use the V2 format.
      *
      * @param buffer buffer to write to
      */
-    public void serializeCompact(ByteBuffer buffer) {
+    @Deprecated
+    public void serializeCompactLegacy(ByteBuffer buffer) {
         byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES_V1);
-        if (chainWorkBytes.length < CHAIN_WORK_BYTES_V1) {
-            // Pad to the right size.
-            buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES_V1 - chainWorkBytes.length);
-        }
         buffer.put(chainWorkBytes);
         buffer.putInt(getHeight());
         // Using unsafeBitcoinSerialize here can give us direct access to the same bytes we read off the wire,
@@ -149,10 +147,6 @@ public class StoredBlock {
      */
     public void serializeCompactV2(ByteBuffer buffer) {
         byte[] chainWorkBytes = Utils.bigIntegerToBytes(getChainWork(), CHAIN_WORK_BYTES_V2);
-        if (chainWorkBytes.length < CHAIN_WORK_BYTES_V2) {
-            // Pad to the right size.
-            buffer.put(EMPTY_BYTES, 0, CHAIN_WORK_BYTES_V2 - chainWorkBytes.length);
-        }
         buffer.put(chainWorkBytes);
         buffer.putInt(getHeight());
         // Using unsafeBitcoinSerialize here can give us direct access to the same bytes we read off the wire,

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -60,20 +60,20 @@ public class StoredBlockTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void serializeCompact_forNegativeChainWork_throwsException() {
+    public void serializeCompactLegacy_forNegativeChainWork_throwsException() {
 
         StoredBlock blockToStore = new StoredBlock(block, NEGATIVE_CHAIN_WORK, blockHeight);
 
         // serialize block should throw illegal argument exception
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
     @Test
-    public void serializeAndDeserializeCompact_forZeroChainWork_works() {
+    public void serializeAndDeserializeCompactLegacy_forZeroChainWork_works() {
         StoredBlock blockToStore = new StoredBlock(block, ZERO_CHAIN_WORK, blockHeight);
 
         // serialize block
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
         assertEquals(blockCapacity, blockBuffer.position());
 
         // deserialize block
@@ -83,12 +83,12 @@ public class StoredBlockTest {
     }
 
     @Test
-    public void serializeAndDeserializeCompact_forSmallChainWork_works() {
+    public void serializeAndDeserializeCompactLegacy_forSmallChainWork_works() {
 
         StoredBlock blockToStore = new StoredBlock(block, SMALL_CHAIN_WORK, blockHeight);
 
         // serialize block
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
         assertEquals(blockCapacity, blockBuffer.position());
 
         // deserialize block
@@ -98,11 +98,11 @@ public class StoredBlockTest {
     }
 
     @Test
-    public void serializeAndDeserializeCompact_for8bytesChainWork_works() {
+    public void serializeAndDeserializeCompactLegacy_for8BytesChainWork_works() {
         StoredBlock blockToStore = new StoredBlock(block, EIGHT_BYTES_WORK_V1, blockHeight);
 
         // serialize block
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
         assertEquals(blockCapacity, blockBuffer.position());
 
         // deserialize block
@@ -112,11 +112,11 @@ public class StoredBlockTest {
     }
 
     @Test
-    public void serializeAndDeserializeCompact_forMax12bytesChainWork_works() {
+    public void serializeAndDeserializeCompactLegacy_forMax12BytesChainWork_works() {
         StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V1, blockHeight);
 
         // serialize block
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
         assertEquals(blockCapacity, blockBuffer.position());
 
         // deserialize block
@@ -126,27 +126,27 @@ public class StoredBlockTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void serializeCompact_for13bytesChainWork_throwsException() {
+    public void serializeCompactLegacy_for13BytesChainWork_throwsException() {
         StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V1, blockHeight);
 
         // serialize block should throw illegal argument exception
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void serializeCompact_for32bytesChainWork_throwsException() {
+    public void serializeCompactLegacy_for32BytesChainWork_throwsException() {
         StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V2, blockHeight);
 
         // serialize block should throw illegal argument exception
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void serializeCompact_forMoreThan32bytesChainWork_throwsException() {
+    public void serializeCompactLegacy_forMoreThan32BytesChainWork_throwsException() {
         StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V2, blockHeight);
 
         // serialize block should throw illegal argument exception
-        blockToStore.serializeCompact(blockBuffer);
+        blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
 

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -1,5 +1,7 @@
 package co.rsk.bitcoinj.core;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -8,9 +10,6 @@ import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class StoredBlockTest {
 
@@ -203,18 +202,5 @@ public class StoredBlockTest {
         blockToStore.serializeCompactV2(buf);
         // assert serialized size and that the buffer is full
         assertEquals(StoredBlock.COMPACT_SERIALIZED_SIZE_V2, buf.position());
-    }
-
-    @Test
-    public void moreWorkThan_whenLargerVsSmallerChainWork_shouldReturnTrue() {
-        StoredBlock noWorkBlock = new StoredBlock(block, BigInteger.ZERO, 0);
-        StoredBlock smallWorkBlock = new StoredBlock(block, BigInteger.ONE, 0);
-        StoredBlock maxWorkBlockV1 = new StoredBlock(block, MAX_WORK_V1, 0);
-        StoredBlock maxWorkBlockV2 = new StoredBlock(block, MAX_WORK_V2, 0);
-
-        assertTrue(smallWorkBlock.moreWorkThan(noWorkBlock));
-        assertTrue(maxWorkBlockV1.moreWorkThan(noWorkBlock));
-        assertTrue(maxWorkBlockV1.moreWorkThan(smallWorkBlock));
-        assertTrue(maxWorkBlockV2.moreWorkThan(maxWorkBlockV1));
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -1,8 +1,8 @@
 package co.rsk.bitcoinj.core;
 
+import static co.rsk.bitcoinj.core.StoredBlock.COMPACT_SERIALIZED_SIZE_LEGACY;
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,17 +37,8 @@ public class StoredBlockTest {
     private static final String blockHeader = "00e00820925b77c9ff4d0036aa29f3238cde12e9af9d55c34ed30200000000000000000032a9fa3e12ef87a2327b55db6a16a1227bb381db8b269d90aa3a6e38cf39665f91b47766255d0317c1b1575f";
     private static final int blockHeight = 849137;
     private static final BtcBlock block = bitcoinSerializer.makeBlock(Hex.decode(blockHeader));
-
-    private static final int blockCapacity = StoredBlock.COMPACT_SERIALIZED_SIZE;
-    private ByteBuffer blockBuffer;
-
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
-
-    @Before
-    public void setUp() {
-        blockBuffer = ByteBuffer.allocate(blockCapacity);
-    }
 
     @Test
     public void newStoredBlock_createsExpectedBlock() {
@@ -61,7 +52,7 @@ public class StoredBlockTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void serializeCompactLegacy_forNegativeChainWork_throwsException() {
-
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         StoredBlock blockToStore = new StoredBlock(block, NEGATIVE_CHAIN_WORK, blockHeight);
 
         // serialize block should throw illegal argument exception
@@ -73,8 +64,9 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, ZERO_CHAIN_WORK, blockHeight);
 
         // serialize block
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
-        assertEquals(blockCapacity, blockBuffer.position());
+        assertEquals(COMPACT_SERIALIZED_SIZE_LEGACY, blockBuffer.position());
 
         // deserialize block
         blockBuffer.rewind();
@@ -84,12 +76,12 @@ public class StoredBlockTest {
 
     @Test
     public void serializeAndDeserializeCompactLegacy_forSmallChainWork_works() {
-
         StoredBlock blockToStore = new StoredBlock(block, SMALL_CHAIN_WORK, blockHeight);
 
         // serialize block
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
-        assertEquals(blockCapacity, blockBuffer.position());
+        assertEquals(COMPACT_SERIALIZED_SIZE_LEGACY, blockBuffer.position());
 
         // deserialize block
         blockBuffer.rewind();
@@ -102,8 +94,9 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, EIGHT_BYTES_WORK_V1, blockHeight);
 
         // serialize block
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
-        assertEquals(blockCapacity, blockBuffer.position());
+        assertEquals(COMPACT_SERIALIZED_SIZE_LEGACY, blockBuffer.position());
 
         // deserialize block
         blockBuffer.rewind();
@@ -116,8 +109,9 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V1, blockHeight);
 
         // serialize block
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
-        assertEquals(blockCapacity, blockBuffer.position());
+        assertEquals(COMPACT_SERIALIZED_SIZE_LEGACY, blockBuffer.position());
 
         // deserialize block
         blockBuffer.rewind();
@@ -130,6 +124,7 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V1, blockHeight);
 
         // serialize block should throw illegal argument exception
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
@@ -138,6 +133,7 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V2, blockHeight);
 
         // serialize block should throw illegal argument exception
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
@@ -146,6 +142,7 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V2, blockHeight);
 
         // serialize block should throw illegal argument exception
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactLegacy(blockBuffer);
     }
 
@@ -155,6 +152,7 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, NEGATIVE_CHAIN_WORK, blockHeight);
 
         // serialize block should throw illegal argument exception
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactV2(blockBuffer);
     }
 
@@ -163,6 +161,7 @@ public class StoredBlockTest {
         StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V2, blockHeight);
 
         // serialize block should throw illegal argument exception
+        ByteBuffer blockBuffer = ByteBuffer.allocate(COMPACT_SERIALIZED_SIZE_LEGACY);
         blockToStore.serializeCompactV2(blockBuffer);
     }
 

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -1,23 +1,49 @@
 package co.rsk.bitcoinj.core;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.spongycastle.util.encoders.Hex;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StoredBlockTest {
+
+    private static final BigInteger NEGATIVE_CHAIN_WORK = BigInteger.valueOf(-1);
+    private static final BigInteger ZERO_CHAIN_WORK = BigInteger.ZERO;
+    private static final BigInteger SMALL_CHAIN_WORK = BigInteger.ONE;
+    // 8 bytes chain work
+    private static final BigInteger EIGHT_BYTES_WORK_V1 = new BigInteger("ffffffffffffffff", 16); // 8 bytes
+    // Max chain work to fit in 12 bytes
+    private static final BigInteger MAX_WORK_V1 = new BigInteger(/* 12 bytes */ "ffffffffffffffffffffffff", 16);
+    // Chain work too large to fit in 12 bytes
+    private static final BigInteger TOO_LARGE_WORK_V1 = new BigInteger(/* 13 bytes */ "ffffffffffffffffffffffffff", 16);
+    // Max chain work to fit in 32 bytes
+    private static final BigInteger MAX_WORK_V2 = new BigInteger(/* 32 bytes */
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+    // Chain work too large to fit in 32 bytes
+    private static final BigInteger TOO_LARGE_WORK_V2 = new BigInteger(/* 33 bytes */
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16);
+
     private static final NetworkParameters mainnet = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+
+    private static final BitcoinSerializer bitcoinSerializer = new BitcoinSerializer(mainnet, false);
 
     // Just an arbitrary block
     private static final String blockHeader = "00e00820925b77c9ff4d0036aa29f3238cde12e9af9d55c34ed30200000000000000000032a9fa3e12ef87a2327b55db6a16a1227bb381db8b269d90aa3a6e38cf39665f91b47766255d0317c1b1575f";
     private static final int blockHeight = 849137;
-    private static final BtcBlock block = new BtcBlock(mainnet, Hex.decode(blockHeader));
+    private static final BtcBlock block = bitcoinSerializer.makeBlock(Hex.decode(blockHeader));
 
     private static final int blockCapacity = StoredBlock.COMPACT_SERIALIZED_SIZE;
     private ByteBuffer blockBuffer;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -26,19 +52,26 @@ public class StoredBlockTest {
 
     @Test
     public void newStoredBlock_createsExpectedBlock() {
-        BigInteger chainWork = new BigInteger("ffffffffffffffff", 16); // 8 bytes
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+        StoredBlock blockToStore = new StoredBlock(block, EIGHT_BYTES_WORK_V1, blockHeight);
 
         // assert block was correctly created
-        assertEquals(chainWork, blockToStore.getChainWork());
+        assertEquals(EIGHT_BYTES_WORK_V1, blockToStore.getChainWork());
         assertEquals(block, blockToStore.getHeader());
         assertEquals(blockHeight, blockToStore.getHeight());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void serializeCompact_forNegativeChainWork_throwsException() {
+
+        StoredBlock blockToStore = new StoredBlock(block, NEGATIVE_CHAIN_WORK, blockHeight);
+
+        // serialize block should throw illegal argument exception
+        blockToStore.serializeCompact(blockBuffer);
+    }
+
     @Test
     public void serializeAndDeserializeCompact_forZeroChainWork_works() {
-        BigInteger chainWork = BigInteger.ZERO;
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+        StoredBlock blockToStore = new StoredBlock(block, ZERO_CHAIN_WORK, blockHeight);
 
         // serialize block
         blockToStore.serializeCompact(blockBuffer);
@@ -52,8 +85,8 @@ public class StoredBlockTest {
 
     @Test
     public void serializeAndDeserializeCompact_forSmallChainWork_works() {
-        BigInteger chainWork = BigInteger.ONE;
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+
+        StoredBlock blockToStore = new StoredBlock(block, SMALL_CHAIN_WORK, blockHeight);
 
         // serialize block
         blockToStore.serializeCompact(blockBuffer);
@@ -67,8 +100,7 @@ public class StoredBlockTest {
 
     @Test
     public void serializeAndDeserializeCompact_for8bytesChainWork_works() {
-        BigInteger chainWork = new BigInteger("ffffffffffffffff", 16); // 8 bytes
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+        StoredBlock blockToStore = new StoredBlock(block, EIGHT_BYTES_WORK_V1, blockHeight);
 
         // serialize block
         blockToStore.serializeCompact(blockBuffer);
@@ -82,8 +114,7 @@ public class StoredBlockTest {
 
     @Test
     public void serializeAndDeserializeCompact_forMax12bytesChainWork_works() {
-        BigInteger chainWork = new BigInteger("ffffffffffffffffffffffff", 16); // max chain work to fit in 12 unsigned bytes
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+        StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V1, blockHeight);
 
         // serialize block
         blockToStore.serializeCompact(blockBuffer);
@@ -97,10 +128,93 @@ public class StoredBlockTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void serializeCompact_for13bytesChainWork_throwsException() {
-        BigInteger chainWork = new BigInteger("ffffffffffffffffffffffff", 16).add(BigInteger.valueOf(1)); // too large chain work to fit in 12 unsigned bytes
-        StoredBlock blockToStore = new StoredBlock(block, chainWork, blockHeight);
+        StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V1, blockHeight);
 
         // serialize block should throw illegal argument exception
         blockToStore.serializeCompact(blockBuffer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void serializeCompact_for32bytesChainWork_throwsException() {
+        StoredBlock blockToStore = new StoredBlock(block, MAX_WORK_V2, blockHeight);
+
+        // serialize block should throw illegal argument exception
+        blockToStore.serializeCompact(blockBuffer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void serializeCompact_forMoreThan32bytesChainWork_throwsException() {
+        StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V2, blockHeight);
+
+        // serialize block should throw illegal argument exception
+        blockToStore.serializeCompact(blockBuffer);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void serializeCompactV2_forNegativeChainWork_throwsException() {
+        StoredBlock blockToStore = new StoredBlock(block, NEGATIVE_CHAIN_WORK, blockHeight);
+
+        // serialize block should throw illegal argument exception
+        blockToStore.serializeCompactV2(blockBuffer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void serializeCompactV2_forMoreThan32bytesChainWork_throwsException() {
+        StoredBlock blockToStore = new StoredBlock(block, TOO_LARGE_WORK_V2, blockHeight);
+
+        // serialize block should throw illegal argument exception
+        blockToStore.serializeCompactV2(blockBuffer);
+    }
+
+    @Test
+    public void serializeCompactV2_forZeroChainWork_works() {
+        testSerializeCompactV2(ZERO_CHAIN_WORK);
+    }
+
+    @Test
+    public void serializeCompactV2_forSmallChainWork_works() {
+        testSerializeCompactV2(SMALL_CHAIN_WORK);
+    }
+
+    @Test
+    public void serializeCompactV2_for8BytesChainWork_works() {
+        testSerializeCompactV2(EIGHT_BYTES_WORK_V1);
+    }
+
+    @Test
+    public void serializeCompactV2_for12ByteChainWork_works() {
+        testSerializeCompactV2(MAX_WORK_V1);
+    }
+
+    @Test
+    public void serializeCompactV2_forTooLargeWorkV1_works() {
+        testSerializeCompactV2(TOO_LARGE_WORK_V1);
+    }
+
+    @Test
+    public void serializeCompactV2_for32BytesChainWork_works() {
+        testSerializeCompactV2(MAX_WORK_V2);
+    }
+
+    private void testSerializeCompactV2(BigInteger chainWork) {
+        StoredBlock blockToStore = new StoredBlock(block, chainWork, 0);
+        ByteBuffer buf = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE_V2);
+        blockToStore.serializeCompactV2(buf);
+        // assert serialized size and that the buffer is full
+        assertEquals(StoredBlock.COMPACT_SERIALIZED_SIZE_V2, buf.position());
+    }
+
+    @Test
+    public void moreWorkThan_whenLargerVsSmallerChainWork_shouldReturnTrue() {
+        StoredBlock noWorkBlock = new StoredBlock(block, BigInteger.ZERO, 0);
+        StoredBlock smallWorkBlock = new StoredBlock(block, BigInteger.ONE, 0);
+        StoredBlock maxWorkBlockV1 = new StoredBlock(block, MAX_WORK_V1, 0);
+        StoredBlock maxWorkBlockV2 = new StoredBlock(block, MAX_WORK_V2, 0);
+
+        assertTrue(smallWorkBlock.moreWorkThan(noWorkBlock));
+        assertTrue(maxWorkBlockV1.moreWorkThan(noWorkBlock));
+        assertTrue(maxWorkBlockV1.moreWorkThan(smallWorkBlock));
+        assertTrue(maxWorkBlockV2.moreWorkThan(maxWorkBlockV1));
     }
 }


### PR DESCRIPTION
## Description

- Add serializeCompactV2 method to serialize block with 32-byte chainwork
- Add tests for serializeCompactV2

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
