### PR TITLE
Add deserializeCompactV2 method to deserialize block with 32-byte chain work

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/core/CheckpointManager.java
+++ b/src/main/java/co/rsk/bitcoinj/core/CheckpointManager.java
@@ -135,7 +135,7 @@ public class CheckpointManager {
             for (int i = 0; i < numCheckpoints; i++) {
                 if (dis.read(buffer.array(), 0, size) < size)
                     throw new IOException("Incomplete read whilst loading checkpoints.");
-                StoredBlock block = StoredBlock.deserializeCompact(params, buffer);
+                StoredBlock block = StoredBlock.deserializeCompactLegacy(params, buffer);
                 buffer.position(0);
                 checkpoints.put(block.getHeader().getTimeSeconds(), block);
             }
@@ -173,7 +173,7 @@ public class CheckpointManager {
                 buffer.position(0);
                 buffer.put(bytes);
                 buffer.position(0);
-                StoredBlock block = StoredBlock.deserializeCompact(params, buffer);
+                StoredBlock block = StoredBlock.deserializeCompactLegacy(params, buffer);
                 checkpoints.put(block.getHeader().getTimeSeconds(), block);
             }
             HashCode hash = hasher.hash();

--- a/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
+++ b/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
@@ -168,13 +168,7 @@ public class StoredBlock {
      */
     @Deprecated
     public static StoredBlock deserializeCompactLegacy(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
-        byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_LEGACY];
-        buffer.get(chainWorkBytes);
-        BigInteger chainWork = new BigInteger(1, chainWorkBytes);
-        int height = buffer.getInt();  // +4 bytes
-        byte[] header = new byte[BtcBlock.HEADER_SIZE + 1];    // Extra byte for the 00 transactions length.
-        buffer.get(header, 0, BtcBlock.HEADER_SIZE);
-        return new StoredBlock(params.getDefaultSerializer().makeBlock(header), chainWork, height);
+        return deserializeCompact(params, buffer, StoredBlock.CHAIN_WORK_BYTES_LEGACY);
     }
 
     /**
@@ -184,7 +178,12 @@ public class StoredBlock {
      * @return deserialized stored block
      */
     public static StoredBlock deserializeCompactV2(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
-        byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_V2];
+        return deserializeCompact(params, buffer, StoredBlock.CHAIN_WORK_BYTES_V2);
+    }
+
+    private static StoredBlock deserializeCompact(NetworkParameters params, ByteBuffer buffer,
+        int chainWorkSize) {
+        byte[] chainWorkBytes = new byte[chainWorkSize];
         buffer.get(chainWorkBytes);
         BigInteger chainWork = new BigInteger(1, chainWorkBytes);
         int height = buffer.getInt();  // +4 bytes

--- a/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
+++ b/src/main/java/co/rsk/bitcoinj/core/StoredBlock.java
@@ -157,6 +157,8 @@ public class StoredBlock {
     }
 
     /**
+     * @deprecated Use {@link #deserializeCompactV2(NetworkParameters, ByteBuffer)} instead.
+     *
      * Deserializes the stored block from a custom packed format. Used internally.
      * As of June 22, 2024, it takes 12 unsigned bytes to store the chain work value,
      * so developers should use the V2 format.
@@ -164,7 +166,8 @@ public class StoredBlock {
      * @param buffer data to deserialize
      * @return deserialized stored block
      */
-    public static StoredBlock deserializeCompact(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
+    @Deprecated
+    public static StoredBlock deserializeCompactLegacy(NetworkParameters params, ByteBuffer buffer) throws ProtocolException {
         byte[] chainWorkBytes = new byte[StoredBlock.CHAIN_WORK_BYTES_LEGACY];
         buffer.get(chainWorkBytes);
         BigInteger chainWork = new BigInteger(1, chainWorkBytes);

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -166,40 +166,44 @@ public class StoredBlockTest {
     }
 
     @Test
-    public void serializeCompactV2_forZeroChainWork_works() {
-        testSerializeCompactV2(ZERO_CHAIN_WORK);
+    public void serializeAndDeserializeCompactV2_forZeroChainWork_works() {
+        testSerializeAndDeserializeCompactV2(ZERO_CHAIN_WORK);
     }
 
     @Test
-    public void serializeCompactV2_forSmallChainWork_works() {
-        testSerializeCompactV2(SMALL_CHAIN_WORK);
+    public void serializeAndDeserializeCompactV2forSmallChainWork_works() {
+        testSerializeAndDeserializeCompactV2(SMALL_CHAIN_WORK);
     }
 
     @Test
-    public void serializeCompactV2_for8BytesChainWork_works() {
-        testSerializeCompactV2(EIGHT_BYTES_WORK_V1);
+    public void serializeAndDeserializeCompactV2for8BytesChainWork_works() {
+        testSerializeAndDeserializeCompactV2(EIGHT_BYTES_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_for12ByteChainWork_works() {
-        testSerializeCompactV2(MAX_WORK_V1);
+    public void serializeAndDeserializeCompactV2for12ByteChainWork_works() {
+        testSerializeAndDeserializeCompactV2(MAX_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_forTooLargeWorkV1_works() {
-        testSerializeCompactV2(TOO_LARGE_WORK_V1);
+    public void serializeAndDeserializeCompactV2forTooLargeWorkV1_works() {
+        testSerializeAndDeserializeCompactV2(TOO_LARGE_WORK_V1);
     }
 
     @Test
-    public void serializeCompactV2_for32BytesChainWork_works() {
-        testSerializeCompactV2(MAX_WORK_V2);
+    public void serializeAndDeserializeCompactV2for32BytesChainWork_works() {
+        testSerializeAndDeserializeCompactV2(MAX_WORK_V2);
     }
 
-    private void testSerializeCompactV2(BigInteger chainWork) {
+    private void testSerializeAndDeserializeCompactV2(BigInteger chainWork) {
         StoredBlock blockToStore = new StoredBlock(block, chainWork, 0);
         ByteBuffer buf = ByteBuffer.allocate(StoredBlock.COMPACT_SERIALIZED_SIZE_V2);
         blockToStore.serializeCompactV2(buf);
         // assert serialized size and that the buffer is full
         assertEquals(StoredBlock.COMPACT_SERIALIZED_SIZE_V2, buf.position());
+
+        buf.rewind();
+        StoredBlock deserializedBlock = StoredBlock.deserializeCompactV2(mainnet, buf);
+        assertEquals(deserializedBlock, blockToStore);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/StoredBlockTest.java
@@ -70,7 +70,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -85,7 +85,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -100,7 +100,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 
@@ -115,7 +115,7 @@ public class StoredBlockTest {
 
         // deserialize block
         blockBuffer.rewind();
-        StoredBlock blockDeserialized = StoredBlock.deserializeCompact(mainnet, blockBuffer);
+        StoredBlock blockDeserialized = StoredBlock.deserializeCompactLegacy(mainnet, blockBuffer);
         assertEquals(blockDeserialized, blockToStore);
     }
 


### PR DESCRIPTION
## Description

- Add deserializeCompactV2 method to deserialize block with 32-byte chain work
- Add tests for deserializeCompactV2

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
