### PR TITLE
feat: added Equals to TransactionWitness

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
+++ b/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
@@ -4,6 +4,7 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -17,7 +18,7 @@ public class TransactionWitness {
     private final List<byte[]> pushes;
 
     public TransactionWitness(int pushCount) {
-        pushes = new ArrayList<byte[]>(Math.min(pushCount, Utils.MAX_INITIAL_ARRAY_LENGTH));
+        pushes = new ArrayList<>(Math.min(pushCount, Utils.MAX_INITIAL_ARRAY_LENGTH));
     }
 
     public static TransactionWitness of(List<byte[]> pushes) {
@@ -63,6 +64,38 @@ public class TransactionWitness {
             return new byte[0];
         else
             return pushes.get(pushes.size() - 1);
+    }
+
+
+    @Override
+    public boolean equals(Object otherWitness) {
+        if (this == otherWitness) {
+            return true;
+        }
+
+        if (otherWitness == null || getClass() != otherWitness.getClass()) {
+            return false;
+        }
+
+        TransactionWitness other = (TransactionWitness) otherWitness;
+        if (pushes.size() != other.pushes.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < pushes.size(); i++) {
+            if (!Arrays.equals(pushes.get(i), other.pushes.get(i))) return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        for (byte[] push : pushes) {
+            hashCode = 31 * hashCode + Arrays.hashCode(push);
+        }
+        return hashCode;
     }
 }
 

--- a/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
+++ b/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
@@ -68,22 +68,22 @@ public class TransactionWitness {
 
 
     @Override
-    public boolean equals(Object otherWitness) {
-        if (this == otherWitness) {
+    public boolean equals(Object otherObject) {
+        if (this == otherObject) {
             return true;
         }
 
-        if (otherWitness == null || getClass() != otherWitness.getClass()) {
+        if (otherObject == null || getClass() != otherObject.getClass()) {
             return false;
         }
 
-        TransactionWitness other = (TransactionWitness) otherWitness;
-        if (pushes.size() != other.pushes.size()) {
+        TransactionWitness otherTxWitness = (TransactionWitness) otherObject;
+        if (pushes.size() != otherTxWitness.pushes.size()) {
             return false;
         }
 
         for (int i = 0; i < pushes.size(); i++) {
-            if (!Arrays.equals(pushes.get(i), other.pushes.get(i))) return false;
+            if (!Arrays.equals(pushes.get(i), otherTxWitness.pushes.get(i))) return false;
         }
 
         return true;

--- a/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
+++ b/src/main/java/co/rsk/bitcoinj/core/TransactionWitness.java
@@ -98,4 +98,3 @@ public class TransactionWitness {
         return hashCode;
     }
 }
-

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -97,7 +97,7 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_withTwoTransactionWitness_withDifferentPushCount_shouldBeTrue() {
+    public void equals_withTwoTransactionWitness_withDifferentEmptyPushCount_shouldBeTrue() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
         TransactionWitness transactionWitness2 = new TransactionWitness(2);
@@ -107,7 +107,7 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_betweenNullAndAnEmptyTransactionWitness_shouldBeFalse() {
+    public void equals_withNullAndAnEmptyTransactionWitness_shouldBeFalse() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
 

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -68,6 +68,19 @@ public class TransactionWitnessTest {
     }
 
     @Test
+    public void hashCode_withNoPush_shouldBeOne() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+
+        // act
+        int hashCode = transactionWitness1.hashCode();
+
+        // assert
+        int hashCodeExpected = 1;
+        assertEquals(hashCodeExpected, hashCode);
+    }
+
+    @Test
     public void equals_withADifferentClass_shouldBeFalse() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
@@ -84,6 +97,20 @@ public class TransactionWitnessTest {
 
         // assert
         assertEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void hashCode_withTwoTransactionWitness_withDifferentPushCount_shouldBeEqual() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+
+        // act
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
+
+        // assert
+        assertEquals(hashCode1, hashCode2);
     }
 
     @Test
@@ -118,9 +145,9 @@ public class TransactionWitnessTest {
     @Test
     public void equals_withTwoTransactionWitness_withDifferentPushCountAndPushes_shouldBeFalse() {
         // arrange
+        byte[] push = {0x1};
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
-        byte[] push = {0x1};
         transactionWitness2.setPush(0, push);
 
         // assert
@@ -128,35 +155,95 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeTrue() {
+    public void hashCode_withTwoTransactionWitness_withDifferentPushCountAndPushes_shouldBeDifferent() {
         // arrange
-        TransactionWitness transactionWitness1 = new TransactionWitness(1);
         byte[] push = {0x1};
-        transactionWitness1.setPush(0, push);
-
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
         transactionWitness2.setPush(0, push);
+
+        // act
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
+
+        // assert
+        assertNotEquals(hashCode1, hashCode2);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeTrue() {
+        // arrange
+        byte[] samePush = {0x1};
+
+        TransactionWitness transactionWitness1 = new TransactionWitness(1);
+        transactionWitness1.setPush(0, samePush);
+
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+        transactionWitness2.setPush(0, samePush);
 
         // assert
         assertEquals(transactionWitness1, transactionWitness2);
     }
 
     @Test
+    public void hashCode_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeEqual() {
+        // arrange
+        byte[] samePush = {0x1};
+
+        TransactionWitness transactionWitness1 = new TransactionWitness(1);
+        transactionWitness1.setPush(0, samePush);
+
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+        transactionWitness2.setPush(0, samePush);
+
+        // act
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
+
+        // assert
+        assertEquals(hashCode1, hashCode2);
+    }
+
+    @Test
     public void equals_withTwoTransactionWitnessesWithOneDifferentPush_shouldBeFalse() {
         // arrange
-        TransactionWitness transactionWitness1 = new TransactionWitness(2);
         byte[] samePush = {0x1};
+
+        TransactionWitness transactionWitness1 = new TransactionWitness(2);
         byte[] differentPush = {0x2};
         transactionWitness1.setPush(0, samePush);
         transactionWitness1.setPush(1, differentPush);
 
         TransactionWitness transactionWitness2 = new TransactionWitness(2);
         byte[] anotherDifferentPush = {0x3};
-
         transactionWitness1.setPush(0, samePush);
         transactionWitness2.setPush(0, anotherDifferentPush);
 
         // assert
         assertNotEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void hashCode_withTwoTransactionWitnessesWithOneDifferentPush_shouldBeDifferent() {
+        // arrange
+        byte[] samePush = {0x1};
+
+        TransactionWitness transactionWitness1 = new TransactionWitness(2);
+        byte[] differentPush = {0x2};
+        transactionWitness1.setPush(0, samePush);
+        transactionWitness1.setPush(1, differentPush);
+
+        TransactionWitness transactionWitness2 = new TransactionWitness(2);
+        byte[] anotherDifferentPush = {0x3};
+        transactionWitness1.setPush(0, samePush);
+        transactionWitness2.setPush(0, anotherDifferentPush);
+
+
+        // act
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
+
+        // assert
+        assertNotEquals(hashCode1, hashCode2);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -3,15 +3,13 @@ package co.rsk.bitcoinj.core;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
-import org.junit.Before;
 import org.junit.Test;
 import org.spongycastle.util.encoders.Hex;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.*;
 
 public class TransactionWitnessTest {
     private static final Script redeemScript = new Script(
@@ -58,5 +56,101 @@ public class TransactionWitnessTest {
 
         // act & assert
         assertThrows(NullPointerException.class, () -> TransactionWitness.of(pushes));
+    }
+
+    @Test
+    public void equals_withAnyObject_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+
+        // assert
+        assertNotEquals(new Object(), transactionWitness1);
+    }
+
+    @Test
+    public void equals_withADifferentClass_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+
+        // assert
+        assertNotEquals("test", transactionWitness1);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitness_withZeroPushCount_shouldBeTrue() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+        TransactionWitness transactionWitness2 = new TransactionWitness(0);
+
+        // assert
+        assertEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitness_withOnePushCount_shouldBeTrue() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(1);
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+
+        // assert
+        assertEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitness_withDifferentPushCount2_shouldBeTrue() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(1);
+        TransactionWitness transactionWitness2 = new TransactionWitness(2);
+
+        // assert
+        assertEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void equals_betweenNullAndAnEmptyTransactionWitness_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+
+        // assert
+        assertNotEquals(transactionWitness1, null);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitness_withDifferentPushCountAndPushes_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+        transactionWitness2.setPush(0, new byte[]{0x1});
+
+        // assert
+        assertNotEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeTrue() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(1);
+        transactionWitness1.setPush(0, new byte[]{0x1});
+
+        TransactionWitness transactionWitness2 = new TransactionWitness(1);
+        transactionWitness2.setPush(0, new byte[]{0x1});
+
+        // assert
+        assertEquals(transactionWitness1, transactionWitness2);
+    }
+
+    @Test
+    public void equals_withTwoTransactionWitnessesWithTheSecondElementDifferent_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(2);
+        transactionWitness1.setPush(0, new byte[]{0x1});
+        transactionWitness1.setPush(1, new byte[]{0x2});
+
+        TransactionWitness transactionWitness2 = new TransactionWitness(2);
+        transactionWitness1.setPush(0, new byte[]{0x1});
+        transactionWitness2.setPush(0, new byte[]{0x3});
+
+        // assert
+        assertNotEquals(transactionWitness1, transactionWitness2);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -68,6 +68,15 @@ public class TransactionWitnessTest {
     }
 
     @Test
+    public void equals_withADifferentClass_shouldBeFalse() {
+        // arrange
+        TransactionWitness transactionWitness1 = new TransactionWitness(0);
+
+        // assert
+        assertNotEquals("test", transactionWitness1);
+    }
+
+    @Test
     public void hashCode_withNoPush_shouldBeOne() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
@@ -81,35 +90,15 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_withADifferentClass_shouldBeFalse() {
-        // arrange
-        TransactionWitness transactionWitness1 = new TransactionWitness(0);
-
-        // assert
-        assertNotEquals("test", transactionWitness1);
-    }
-
-    @Test
     public void equals_withTwoTransactionWitness_withZeroPushCount_shouldBeTrue() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
         TransactionWitness transactionWitness2 = new TransactionWitness(0);
-
-        // assert
-        assertEquals(transactionWitness1, transactionWitness2);
-    }
-
-    @Test
-    public void hashCode_withTwoTransactionWitness_withDifferentPushCount_shouldBeEqual() {
-        // arrange
-        TransactionWitness transactionWitness1 = new TransactionWitness(0);
-        TransactionWitness transactionWitness2 = new TransactionWitness(1);
-
-        // act
         int hashCode1 = transactionWitness1.hashCode();
         int hashCode2 = transactionWitness2.hashCode();
 
         // assert
+        assertEquals(transactionWitness1, transactionWitness2);
         assertEquals(hashCode1, hashCode2);
     }
 
@@ -118,9 +107,12 @@ public class TransactionWitnessTest {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
 
         // assert
         assertEquals(transactionWitness1, transactionWitness2);
+        assertEquals(hashCode1, hashCode2);
     }
 
     @Test
@@ -128,9 +120,12 @@ public class TransactionWitnessTest {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
         TransactionWitness transactionWitness2 = new TransactionWitness(2);
+        int hashCode1 = transactionWitness1.hashCode();
+        int hashCode2 = transactionWitness2.hashCode();
 
         // assert
         assertEquals(transactionWitness1, transactionWitness2);
+        assertEquals(hashCode1, hashCode2);
     }
 
     @Test
@@ -149,24 +144,11 @@ public class TransactionWitnessTest {
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
         transactionWitness2.setPush(0, push);
-
-        // assert
-        assertNotEquals(transactionWitness1, transactionWitness2);
-    }
-
-    @Test
-    public void hashCode_withTwoTransactionWitness_withDifferentPushCountAndPushes_shouldBeDifferent() {
-        // arrange
-        byte[] push = {0x1};
-        TransactionWitness transactionWitness1 = new TransactionWitness(0);
-        TransactionWitness transactionWitness2 = new TransactionWitness(1);
-        transactionWitness2.setPush(0, push);
-
-        // act
         int hashCode1 = transactionWitness1.hashCode();
         int hashCode2 = transactionWitness2.hashCode();
 
         // assert
+        assertNotEquals(transactionWitness1, transactionWitness2);
         assertNotEquals(hashCode1, hashCode2);
     }
 
@@ -181,26 +163,11 @@ public class TransactionWitnessTest {
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
         transactionWitness2.setPush(0, samePush);
 
-        // assert
-        assertEquals(transactionWitness1, transactionWitness2);
-    }
-
-    @Test
-    public void hashCode_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeEqual() {
-        // arrange
-        byte[] samePush = {0x1};
-
-        TransactionWitness transactionWitness1 = new TransactionWitness(1);
-        transactionWitness1.setPush(0, samePush);
-
-        TransactionWitness transactionWitness2 = new TransactionWitness(1);
-        transactionWitness2.setPush(0, samePush);
-
-        // act
         int hashCode1 = transactionWitness1.hashCode();
         int hashCode2 = transactionWitness2.hashCode();
 
         // assert
+        assertEquals(transactionWitness1, transactionWitness2);
         assertEquals(hashCode1, hashCode2);
     }
 
@@ -219,31 +186,11 @@ public class TransactionWitnessTest {
         transactionWitness1.setPush(0, samePush);
         transactionWitness2.setPush(0, anotherDifferentPush);
 
-        // assert
-        assertNotEquals(transactionWitness1, transactionWitness2);
-    }
-
-    @Test
-    public void hashCode_withTwoTransactionWitnessesWithOneDifferentPush_shouldBeDifferent() {
-        // arrange
-        byte[] samePush = {0x1};
-
-        TransactionWitness transactionWitness1 = new TransactionWitness(2);
-        byte[] differentPush = {0x2};
-        transactionWitness1.setPush(0, samePush);
-        transactionWitness1.setPush(1, differentPush);
-
-        TransactionWitness transactionWitness2 = new TransactionWitness(2);
-        byte[] anotherDifferentPush = {0x3};
-        transactionWitness1.setPush(0, samePush);
-        transactionWitness2.setPush(0, anotherDifferentPush);
-
-
-        // act
         int hashCode1 = transactionWitness1.hashCode();
         int hashCode2 = transactionWitness2.hashCode();
 
         // assert
+        assertNotEquals(transactionWitness1, transactionWitness2);
         assertNotEquals(hashCode1, hashCode2);
     }
 }

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -103,7 +103,7 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_withTwoTransactionWitness_withOnePushCount_shouldBeTrue() {
+    public void equals_withTwoTransactionWitness_withSamePushes_shouldBeTrue() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);

--- a/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
+++ b/src/test/java/co/rsk/bitcoinj/core/TransactionWitnessTest.java
@@ -97,7 +97,7 @@ public class TransactionWitnessTest {
     }
 
     @Test
-    public void equals_withTwoTransactionWitness_withDifferentPushCount2_shouldBeTrue() {
+    public void equals_withTwoTransactionWitness_withDifferentPushCount_shouldBeTrue() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
         TransactionWitness transactionWitness2 = new TransactionWitness(2);
@@ -120,7 +120,8 @@ public class TransactionWitnessTest {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(0);
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
-        transactionWitness2.setPush(0, new byte[]{0x1});
+        byte[] push = {0x1};
+        transactionWitness2.setPush(0, push);
 
         // assert
         assertNotEquals(transactionWitness1, transactionWitness2);
@@ -130,25 +131,30 @@ public class TransactionWitnessTest {
     public void equals_withTwoTransactionWitnessesWithTheSameElementsPushed_shouldBeTrue() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(1);
-        transactionWitness1.setPush(0, new byte[]{0x1});
+        byte[] push = {0x1};
+        transactionWitness1.setPush(0, push);
 
         TransactionWitness transactionWitness2 = new TransactionWitness(1);
-        transactionWitness2.setPush(0, new byte[]{0x1});
+        transactionWitness2.setPush(0, push);
 
         // assert
         assertEquals(transactionWitness1, transactionWitness2);
     }
 
     @Test
-    public void equals_withTwoTransactionWitnessesWithTheSecondElementDifferent_shouldBeFalse() {
+    public void equals_withTwoTransactionWitnessesWithOneDifferentPush_shouldBeFalse() {
         // arrange
         TransactionWitness transactionWitness1 = new TransactionWitness(2);
-        transactionWitness1.setPush(0, new byte[]{0x1});
-        transactionWitness1.setPush(1, new byte[]{0x2});
+        byte[] samePush = {0x1};
+        byte[] differentPush = {0x2};
+        transactionWitness1.setPush(0, samePush);
+        transactionWitness1.setPush(1, differentPush);
 
         TransactionWitness transactionWitness2 = new TransactionWitness(2);
-        transactionWitness1.setPush(0, new byte[]{0x1});
-        transactionWitness2.setPush(0, new byte[]{0x3});
+        byte[] anotherDifferentPush = {0x3};
+
+        transactionWitness1.setPush(0, samePush);
+        transactionWitness2.setPush(0, anotherDifferentPush);
 
         // assert
         assertNotEquals(transactionWitness1, transactionWitness2);


### PR DESCRIPTION
Creating custom `equals` and `hashCode` for the TransactionWitness object. Two TransactionWitness objects are equal if they have the same pushes. We based both on the bitcoinj implementation.