### PR TITLE
Modify createMultisigOutputScript to check that pubkeys are leq than 20

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ScriptBuilder.java
@@ -269,6 +269,7 @@ public class ScriptBuilder {
     public static Script createMultiSigOutputScript(int threshold, List<BtcECKey> pubkeys) {
         checkArgument(threshold > 0);
         checkArgument(threshold <= pubkeys.size());
+        checkArgument(pubkeys.size() <= 20); // That's the max OP_CHECKMULTISIG allows.
         ScriptBuilder builder = new ScriptBuilder();
         builder.number(threshold);
         for (BtcECKey key : pubkeys) {

--- a/src/test/java/co/rsk/bitcoinj/script/ScriptBuilderTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ScriptBuilderTest.java
@@ -75,11 +75,31 @@ public class ScriptBuilderTest {
         assertGivenNumberOfKeysCreatesAValidMultiSigOutputScript(numberOfKeys);
     }
 
+    @Test
+    public void createMultiSigOutputScript_with20PubKeys_shouldReturnAValidScript() {
+        // Arrange
+        int numberOfKeys = 20;
+
+        // Act & Assert
+        assertGivenNumberOfKeysCreatesAValidMultiSigOutputScript(numberOfKeys);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createMultiSigOutputScript_withMoreThan20PubKeys_shouldThrowAnException() {
+        // Arrange
+        List<BtcECKey> ecKeys = RedeemScriptUtils.getNKeys(21);
+        int expectedThreshold = 11;
+
+        // Act & Assert
+        ScriptBuilder.createMultiSigOutputScript(expectedThreshold, ecKeys);
+    }
+
     private static void assertGivenNumberOfKeysCreatesAValidMultiSigOutputScript(int numberOfKeys) {
         List<BtcECKey> ecKeys = RedeemScriptUtils.getNKeys(numberOfKeys);
         int expectedThreshold = numberOfKeys / 2 + 1;
 
         Script multiSigOutputScript = ScriptBuilder.createMultiSigOutputScript(expectedThreshold, ecKeys);
+        assertTrue(multiSigOutputScript.isSentToMultiSig());
 
         // threshold (1) + pubkeys (numberOfKeys) + num of pubKeys (1) + OP_CHECKMULTISIG (1)
         int expectedNumberOfChunks = numberOfKeys + 3;
@@ -103,5 +123,4 @@ public class ScriptBuilderTest {
         int actualMultiSigOpCode = chunks.get(index).opcode;
         assertEquals(ScriptOpCodes.OP_CHECKMULTISIG, actualMultiSigOpCode);
     }
-
 }


### PR DESCRIPTION
Since OP_CHECKMULTISIG opcode allows up to 20 pubkeys, we need to add that check when creating a multisig output script