### PR TITLE
Enforce minimal encoding (without leading zeroes) for numbers

### DIFF
--- a/src/main/java/co/rsk/bitcoinj/script/ScriptChunk.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ScriptChunk.java
@@ -183,8 +183,13 @@ public class ScriptChunk {
             throw new IllegalArgumentException("Chunk has null data.");
         }
         int dataLength = data.length;
+        byte moreSignificantByte = data[dataLength - 1];
 
-        int signByte = data[dataLength - 1] & 0x80;
+        if (moreSignificantByte == 0x00) {
+            throw new IllegalArgumentException("Number from chunk does not have minimal encoding.");
+        }
+
+        int signByte = moreSignificantByte & 0x80;
         boolean isPositive = signByte == 0;
         if (!isPositive) {
             throw new IllegalArgumentException("Number from chunk is not positive.");

--- a/src/main/java/co/rsk/bitcoinj/script/ScriptChunk.java
+++ b/src/main/java/co/rsk/bitcoinj/script/ScriptChunk.java
@@ -183,16 +183,20 @@ public class ScriptChunk {
             throw new IllegalArgumentException("Chunk has null data.");
         }
         int dataLength = data.length;
-        byte moreSignificantByte = data[dataLength - 1];
+        byte mostSignificantByte = data[dataLength - 1];
 
-        if (moreSignificantByte == 0x00) {
-            throw new IllegalArgumentException("Number from chunk does not have minimal encoding.");
-        }
-
-        int signByte = moreSignificantByte & 0x80;
+        int signByte = mostSignificantByte & 0x80;
         boolean isPositive = signByte == 0;
         if (!isPositive) {
             throw new IllegalArgumentException("Number from chunk is not positive.");
+        }
+
+        boolean hasPadding = mostSignificantByte == 0;
+        if (hasPadding) {
+            boolean shouldAllowPadding = (data[dataLength - 2] & 0x80) != 0;
+            if (!shouldAllowPadding) {
+                throw new IllegalArgumentException("Number from chunk does not have minimal encoding.");
+            }
         }
 
         if (dataLength > 4) {

--- a/src/test/java/co/rsk/bitcoinj/script/ScriptChunkTest.java
+++ b/src/test/java/co/rsk/bitcoinj/script/ScriptChunkTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class ScriptChunkTest {
 
     @Test
@@ -173,6 +175,23 @@ public class ScriptChunkTest {
         ScriptChunk chunk = script.chunks.get(0);
         assertFalse(chunk.isPositiveN());
         assertThrows(IllegalArgumentException.class, chunk::decodePositiveN);
+    }
+
+    @Test
+    public void decodePositiveN_forNumberWithoutMinimalEncoding_throwsIAE() {
+        byte zero = 0x00;
+        for (int n=0; n<20; n++) {
+            int i = (1 << n); // i = (2^n)
+            byte[] numWithoutMinimalEncoding = new byte[] {(byte) i, zero};
+
+            ScriptBuilder builder = new ScriptBuilder();
+            builder.data(numWithoutMinimalEncoding);
+            Script script = builder.build();
+
+            ScriptChunk chunk = script.chunks.get(0);
+            assertFalse(chunk.isPositiveN());
+            assertThrows(IllegalArgumentException.class, chunk::decodePositiveN);
+        }
     }
 
     @Test


### PR DESCRIPTION
As a general rule, Bitcoin core enforces minimal encoding for numbers.
This protection was missing in the `decodePositiveNConsideringEncoding` function, which allowed leading zeroes, causing ambiguous encoding acceptance.